### PR TITLE
Add `Project.sourceSetNames` extension

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -441,12 +441,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 22 15:53:57 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 14:42:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
@@ -939,12 +939,12 @@ This report was generated on **Mon Nov 22 15:53:57 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 22 15:53:57 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 14:42:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1353,4 +1353,4 @@ This report was generated on **Mon Nov 22 15:53:57 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 22 15:53:58 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 14:42:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/project/ProjectExtensions.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/project/ProjectExtensions.kt
@@ -59,6 +59,12 @@ public val Project.javaPluginExtension: JavaPluginExtension
 public val Project.sourceSets: SourceSetContainer
     get() = javaPluginExtension.sourceSets
 
+/**
+ * Obtains names of the source sets of this project.
+ */
+public val Project.sourceSetNames: List<SourceSetName>
+    get() = sourceSets.map { s -> SourceSetName(s.name) }
+
 /** Obtains a source set by the given name. */
 public fun Project.sourceSet(name: String): SourceSet = sourceSets.getByName(name)
 

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/project/ProjectExtensionsTest.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/project/ProjectExtensionsTest.kt
@@ -106,4 +106,14 @@ class `'ProjectExtensions' should` {
                 .contains(customName.value)
         }
     }
+
+    @Test
+    fun `obtain names of source sets`() {
+        val sourceSets = project.sourceSets
+        val sourceSetNames = project.sourceSetNames
+
+        val assertNames = assertThat(sourceSetNames)
+        assertNames.hasSize(sourceSets.size)
+        assertNames.containsExactlyElementsIn(sourceSets.map { s -> SourceSetName(s.name) })
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.78</version>
+<version>2.0.0-SNAPSHOT.79</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,4 +25,4 @@
  */
 
 val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.75")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.78")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.79")


### PR DESCRIPTION
This PR extends `Project` with an ability to obtain a list of source set names.
