### PR TITLE
More standard type extensions

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -441,7 +441,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 18:48:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 20:41:08 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -939,7 +939,7 @@ This report was generated on **Tue Nov 23 18:48:34 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 18:48:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 20:41:08 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1353,4 +1353,4 @@ This report was generated on **Tue Nov 23 18:48:35 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 18:48:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 20:41:09 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.79`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.80`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -441,12 +441,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 14:42:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 18:48:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.79`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.80`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
@@ -939,12 +939,12 @@ This report was generated on **Tue Nov 23 14:42:39 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 14:42:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 18:48:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.79`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.80`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1353,4 +1353,4 @@ This report was generated on **Tue Nov 23 14:42:40 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 14:42:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 18:48:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -441,7 +441,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 20:41:08 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 21:15:24 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -939,7 +939,7 @@ This report was generated on **Tue Nov 23 20:41:08 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 20:41:08 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 21:15:24 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1353,4 +1353,4 @@ This report was generated on **Tue Nov 23 20:41:08 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 23 20:41:09 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 21:15:25 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-base/src/main/java/io/spine/tools/gradle/CodeGenerationAction.java
+++ b/plugin-base/src/main/java/io/spine/tools/gradle/CodeGenerationAction.java
@@ -37,7 +37,7 @@ import org.gradle.api.Task;
 import java.io.File;
 import java.util.function.Supplier;
 
-import static io.spine.tools.gradle.StandardTypes.toAbsoluteFile;
+import static io.spine.tools.StandardTypes.toAbsoluteFile;
 
 /**
  * Abstract base for code generation actions.

--- a/plugin-base/src/main/java/io/spine/tools/gradle/ProtobufDependencies.java
+++ b/plugin-base/src/main/java/io/spine/tools/gradle/ProtobufDependencies.java
@@ -26,12 +26,15 @@
 
 package io.spine.tools.gradle;
 
+import io.spine.tools.proto.fs.Directory;
+
 /**
  * A factory of Protobuf-related artifact specs.
  */
 public final class ProtobufDependencies {
 
     private static final String GROUP_ID = "com.google.protobuf";
+    private static final String SOURCE_SET_EXTENSION = Directory.rootName();
     private static final String PROTOBUF_LITE = "protobuf-lite";
     private static final String PROTOC = "protoc";
     private static final PluginId PROTOBUF_PLUGIN_ID = new PluginId(GROUP_ID);
@@ -47,6 +50,14 @@ public final class ProtobufDependencies {
      */
     public static PluginId gradlePlugin() {
         return PROTOBUF_PLUGIN_ID;
+    }
+
+    /**
+     * Obtains the name of the extension of {@code SourceSet} installed by
+     * the Protobuf Gradle plugin.
+     */
+    public static String sourceSetExtensionName() {
+        return SOURCE_SET_EXTENSION;
     }
 
     /**

--- a/plugin-base/src/main/java/io/spine/tools/gradle/ProtobufDependencies.java
+++ b/plugin-base/src/main/java/io/spine/tools/gradle/ProtobufDependencies.java
@@ -53,8 +53,7 @@ public final class ProtobufDependencies {
     }
 
     /**
-     * Obtains the name of the extension of {@code SourceSet} installed by
-     * the Protobuf Gradle plugin.
+     * Obtains the name of the {@code SourceSet} extension installed by the Protobuf Gradle plugin.
      */
     public static String sourceSetExtensionName() {
         return SOURCE_SET_EXTENSION;

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/SourceSetBasedName.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/SourceSetBasedName.kt
@@ -26,6 +26,8 @@
 
 package io.spine.tools.gradle
 
+import io.spine.tools.titlecaseFirstChar
+
 /**
  * An abstract base for names of Gradle project objects that are based on a name of a source set.
  */

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/SourceSetName.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/SourceSetName.kt
@@ -26,6 +26,7 @@
 
 package io.spine.tools.gradle
 
+import io.spine.tools.titlecaseFirstChar
 import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME
 

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/project/ProjectExtensions.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/project/ProjectExtensions.kt
@@ -38,7 +38,7 @@ import io.spine.tools.gradle.ProtobufDependencies.sourceSetExtensionName
 import io.spine.tools.gradle.SourceSetName
 import io.spine.tools.gradle.SourceSetName.Companion.main
 import io.spine.tools.gradle.SourceSetName.Companion.test
-import io.spine.tools.gradle.resolve
+import io.spine.tools.resolve
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/project/ProjectExtensions.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/project/ProjectExtensions.kt
@@ -43,6 +43,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
@@ -97,12 +98,23 @@ public val Project.testArtifact: Artifact
  *
  * For other source sets, the given name would be used as a classifier of the artifact.
  */
-public fun Project.artifact(ss: SourceSetName): Artifact {
-    return when (ss) {
+public fun Project.artifact(ssn: SourceSetName): Artifact {
+    return when (ssn) {
         main -> artifact
         test -> testArtifact
-        else -> toArtifactBuilder().setClassifier(ss.value).build()
+        else -> toArtifactBuilder().setClassifier(ssn.value).build()
     }
+}
+
+/**
+ * Attempts to find a source directory set named `proto` in the given source set.
+ *
+ * @return the found instance or `null` if the source set does not contain Protobuf code.
+ */
+public fun Project.protoDirectorySet(ssn: SourceSetName): SourceDirectorySet? {
+    val sourceSet: SourceSet = sourceSet(ssn)
+    val found = sourceSet.extensions.findByName("proto") as SourceDirectorySet?
+    return found
 }
 
 /**
@@ -120,10 +132,10 @@ private val Project.descriptorsDir: DescriptorsDir
 /**
  * Obtains the descriptor set file for the specified source set of this project.
  */
-public fun Project.descriptorSetFile(ss: SourceSetName): File {
-    val theArtifact = artifact(ss)
+public fun Project.descriptorSetFile(ssn: SourceSetName): File {
+    val theArtifact = artifact(ssn)
     val descriptorSetFile = theArtifact.descriptorSetFile()
-    val dir = descriptorsDir.forSourceSet(ss.value)
+    val dir = descriptorsDir.forSourceSet(ssn.value)
     val path = descriptorSetFile.under(dir)
     return path.toFile()
 }

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/project/ProjectExtensions.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/project/ProjectExtensions.kt
@@ -34,6 +34,7 @@ import io.spine.tools.fs.DescriptorsDir
 import io.spine.tools.fs.DirectoryName.generated
 import io.spine.tools.gradle.Artifact
 import io.spine.tools.gradle.ConfigurationName
+import io.spine.tools.gradle.ProtobufDependencies.sourceSetExtensionName
 import io.spine.tools.gradle.SourceSetName
 import io.spine.tools.gradle.SourceSetName.Companion.main
 import io.spine.tools.gradle.SourceSetName.Companion.test
@@ -113,7 +114,7 @@ public fun Project.artifact(ssn: SourceSetName): Artifact {
  */
 public fun Project.protoDirectorySet(ssn: SourceSetName): SourceDirectorySet? {
     val sourceSet: SourceSet = sourceSet(ssn)
-    val found = sourceSet.extensions.findByName("proto") as SourceDirectorySet?
+    val found = sourceSet.extensions.findByName(sourceSetExtensionName()) as SourceDirectorySet?
     return found
 }
 

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/SourceSetNameTest.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/SourceSetNameTest.kt
@@ -28,6 +28,7 @@ package io.spine.tools.gradle
 
 import com.google.common.truth.Truth.assertThat
 import io.spine.tools.gradle.SourceSetName.Companion.main
+import io.spine.tools.titlecaseFirstChar
 import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/project/GeneratedDirTest.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/project/GeneratedDirTest.kt
@@ -30,7 +30,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.gradle.ProtobufConfigurator
 import io.spine.tools.fs.DirectoryName.generated
 import io.spine.tools.gradle.ProtobufDependencies.gradlePlugin
-import io.spine.tools.gradle.resolve
+import io.spine.tools.resolve
 import io.spine.tools.groovy.ConsumerClosure.closure
 import java.io.File
 import java.nio.file.Path

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.79</version>
+<version>2.0.0-SNAPSHOT.80</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.75</version>
+    <version>2.0.0-SNAPSHOT.76</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.75</version>
+    <version>2.0.0-SNAPSHOT.76</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/tool-base/src/main/java/io/spine/tools/dart/fs/DartFile.java
+++ b/tool-base/src/main/java/io/spine/tools/dart/fs/DartFile.java
@@ -59,7 +59,7 @@ public final class DartFile extends FileWithImports {
 
     @Override
     protected String resolveImport(String line, Path libPath, ExternalModules modules) {
-        ImportStatement statement = new ImportStatement(this, line);
+        ImportStatement statement = ImportStatement.in(this, line);
         ImportStatement resolved = statement.resolve(libPath, modules);
         return resolved.text();
     }

--- a/tool-base/src/main/java/io/spine/tools/dart/fs/ImportStatement.java
+++ b/tool-base/src/main/java/io/spine/tools/dart/fs/ImportStatement.java
@@ -41,7 +41,9 @@ import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static java.util.regex.Pattern.compile;
 
 /**
@@ -66,13 +68,15 @@ final class ImportStatement implements Element, Logging {
      * @param text
      *         the text of the source code line with the import statement
      */
-    ImportStatement(DartFile sourceFile, String text) {
-        this(sourceFile.directory(), text);
+    static ImportStatement in(DartFile sourceFile, String text) {
+        checkNotEmptyOrBlank(text);
+        Path sourceCodeDir = requireNonNull(sourceFile.parent());
+        return new ImportStatement(sourceCodeDir, text);
     }
 
     private ImportStatement(Path sourceDirectory, String text) {
-        this.text = checkNotNull(text);
         this.sourceDirectory = sourceDirectory;
+        this.text = text;
         Matcher matcher = PATTERN.matcher(text);
         checkArgument(
                 matcher.matches(),

--- a/tool-base/src/main/java/io/spine/tools/proto/fs/Directory.java
+++ b/tool-base/src/main/java/io/spine/tools/proto/fs/Directory.java
@@ -38,7 +38,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class Directory extends SourceCodeDirectory {
 
-    @SuppressWarnings("DuplicateStringLiteralInspection") // Same name for different directories.
     private static final String ROOT_NAME = "proto";
 
     private Directory(Path path) {
@@ -51,6 +50,13 @@ public final class Directory extends SourceCodeDirectory {
     static Directory at(Path path) {
         checkNotNull(path);
         return new Directory(path);
+    }
+
+    /**
+     * Obtains a short name for the root directory containing Protobuf code.
+     */
+    public static String rootName() {
+        return ROOT_NAME;
     }
 
     /**

--- a/tool-base/src/main/kotlin/io/spine/tools/StandardTypesExtensions.kt
+++ b/tool-base/src/main/kotlin/io/spine/tools/StandardTypesExtensions.kt
@@ -26,11 +26,21 @@
 
 @file:JvmName("StandardTypes")
 
-package io.spine.tools.gradle
+package io.spine.tools
 
-import org.gradle.api.tasks.SourceSet
+import io.spine.io.Files2
+import io.spine.tools.fs.DirectoryName
+import java.io.File
+import java.util.function.Supplier
 
-/** The name of this source set. */
-public val SourceSet.named: SourceSetName
-    get() = SourceSetName(name)
+/** Obtains a copy of this string with the first character capitalized . */
+public fun String.titlecaseFirstChar(): String = replaceFirstChar(Char::titlecase)
 
+/** Resolves an absolute file name obtained from the supplier. */
+public fun Supplier<String>.toAbsoluteFile(): File = Files2.toAbsolute(get())
+
+/** Adds relative name to this directory. */
+public fun File.resolve(dir: DirectoryName): File = resolve(dir.value())
+
+/** Tells if this is a Protobuf source code file. */
+public fun File.isProtoSource(): Boolean = extension == "proto"

--- a/tool-base/src/test/kotlin/io/spine/tools/StandardTypeExtensionsTest.kt
+++ b/tool-base/src/test/kotlin/io/spine/tools/StandardTypeExtensionsTest.kt
@@ -24,13 +24,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@file:JvmName("StandardTypes")
+package io.spine.tools
 
-package io.spine.tools.gradle
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.util.function.Supplier
+import org.junit.jupiter.api.Test
 
-import org.gradle.api.tasks.SourceSet
+class `'StandardTypeExtensions' should` {
 
-/** The name of this source set. */
-public val SourceSet.named: SourceSetName
-    get() = SourceSetName(name)
+    @Test
+    fun `provide title case version of 'String'`() {
+        assertThat("foo".titlecaseFirstChar())
+            .isEqualTo("Foo")
+        assertThat("Bar".titlecaseFirstChar())
+            .isEqualTo("Bar")
+    }
 
+    @Test
+    fun `convert a 'String' 'Supplier' to absolute file`() {
+        val sup: Supplier<String> = Supplier { "." }
+
+        assertThat(sup.toAbsoluteFile().isAbsolute)
+            .isTrue()
+    }
+
+    @Test
+    fun `tell if a file is a Protobuf source code file`() {
+        assertThat(File("mycode.proto").isProtoSource())
+            .isTrue()
+        assertThat(File("util.java").isProtoSource())
+            .isFalse()
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,4 +25,4 @@
  */
 
 val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.75")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.79")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.80")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,5 +24,5 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.75")
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.76")
 val versionToPublish: String by extra("2.0.0-SNAPSHOT.80")


### PR DESCRIPTION
This PR:
  * Extracts Kotlin extensions of standard types that do not depend on Gradle API into `io.spine.tools.StandardTypeExtensions`.
  * Introduces `Project.protoDirectorySet()` extension function for obtaining a `proto` directory that _may_ be present in the specified source set.
  * Bumps `base` dependency.