### PR TITLE
Allow to replace tokens in test Gradle projects via `GradleProjectSetup`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -444,12 +444,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 17 15:01:15 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 04 18:51:48 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
@@ -945,12 +945,12 @@ This report was generated on **Fri Dec 17 15:01:15 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 17 15:01:15 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 04 18:51:48 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.87`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1362,4 +1362,4 @@ This report was generated on **Fri Dec 17 15:01:15 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 17 15:01:15 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 04 18:51:49 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
@@ -88,7 +88,7 @@ public class GradleProject internal constructor(setup: GradleProjectSetup) {
                 .filter { f -> !f.isIn(buildSrcDir) }
                 .forEach { f ->
                     setup.replacements.forEach { r ->
-                        r.replaceIn(setup.projectDir)
+                        r.replaceIn(f)
                     }
                 }
 

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
@@ -98,7 +98,6 @@ public class GradleProject internal constructor(setup: GradleProjectSetup) {
                         r.replaceIn(f)
                     }
                 }
-
         }
     }
 

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
@@ -56,6 +56,7 @@ public class GradleProject internal constructor(setup: GradleProjectSetup) {
             runner.withEnvironment(setup.environment)
         }
         writeSources(setup)
+        replaceTokens(setup)
     }
 
     public companion object {
@@ -77,6 +78,12 @@ public class GradleProject internal constructor(setup: GradleProjectSetup) {
         private fun writeSources(setup: GradleProjectSetup) {
             val sources = Sources(setup)
             sources.write()
+        }
+
+        private fun replaceTokens(setup: GradleProjectSetup) {
+            setup.replacements.forEach { r ->
+                r.replaceIn(setup.projectDir)
+            }
         }
     }
 

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
@@ -81,8 +81,9 @@ public class GradleProject internal constructor(setup: GradleProjectSetup) {
         }
 
         private fun replaceTokens(setup: GradleProjectSetup) {
+            val buildSrcDir = setup.projectDir.resolve("buildSrc")
             setup.replacements.forEach { r ->
-                r.replaceIn(setup.projectDir)
+                r.replaceIn(setup.projectDir, buildSrcDir)
             }
         }
     }

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
@@ -82,9 +82,16 @@ public class GradleProject internal constructor(setup: GradleProjectSetup) {
 
         private fun replaceTokens(setup: GradleProjectSetup) {
             val buildSrcDir = setup.projectDir.resolve("buildSrc")
-            setup.replacements.forEach { r ->
-                r.replaceIn(setup.projectDir, buildSrcDir)
-            }
+            setup.projectDir
+                .walk()
+                .filter { f -> !f.isDirectory }
+                .filter { f -> !f.isIn(buildSrcDir) }
+                .forEach { f ->
+                    setup.replacements.forEach { r ->
+                        r.replaceIn(setup.projectDir)
+                    }
+                }
+
         }
     }
 
@@ -112,3 +119,15 @@ public class GradleProject internal constructor(setup: GradleProjectSetup) {
         return runner.withArguments(args)
     }
 }
+
+/**
+ * Tells whether the file resides in the [folder].
+ *
+ * If the [folder] is `null`, returns `false`.
+ */
+private fun File.isIn(folder: File?) =
+    if(folder == null) {
+        false
+    } else {
+        this.absolutePath.startsWith(folder.absolutePath)
+    }

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
@@ -80,6 +80,13 @@ public class GradleProject internal constructor(setup: GradleProjectSetup) {
             sources.write()
         }
 
+        /**
+         * Uses the pre-configured [replacements][GradleProjectSetup.replacements] and replaces
+         * the tokens in all files of the [projectDir] and its sub-folders.
+         *
+         * The contents of `projectDir/buildSrc` folder are ignored in this process — as these files
+         * hardly ever may contain the tokenized values.
+         */
         private fun replaceTokens(setup: GradleProjectSetup) {
             val buildSrcDir = setup.projectDir.resolve("buildSrc")
             setup.projectDir

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
@@ -104,6 +104,12 @@ public class GradleProjectSetup internal constructor(
     internal var addPluginUnderTestClasspath = false
         private set
 
+    /**
+     * The text replacements to be made in the files residing under the [projectDir].
+     *
+     * The replacements are not made to the files in the `buildSrc` folder
+     * placed under the [projectDir].
+     */
     internal var replacements: MutableSet<Replacement> = HashSet()
 
     /**
@@ -273,6 +279,10 @@ public class GradleProjectSetup internal constructor(
      *      The latest version of the library is @LATEST_VERSION@.
      * ```
      * where `LATEST_VERSION` is the token name to pass to this method.
+     *
+     * The files placed under the `projectDir/buildSrc` are excluded from the replacements.
+     * This is done so, as the `buildSrc` files are typically copied over from the parent
+     * Gradle project, and thus hardly may contain any tokenized values.
      */
     public fun replace(token: String, replacement: String): GradleProjectSetup {
         val r = Replacement(token, replacement)

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
@@ -274,11 +274,12 @@ public class GradleProjectSetup internal constructor(
      * Upon building the `GradleProject`, traverses through the resulting project directory,
      * and replace all occurrences of the [token] with the passed [replacement] value.
      *
-     * In text, token name must be framed with `@` symbols:
+     * It is recommended to use `@` symbols framing the token name. It's the convention used
+     * by native Gradle plugins. E.g.:
      *```
      *      The latest version of the library is @LATEST_VERSION@.
      * ```
-     * where `LATEST_VERSION` is the token name to pass to this method.
+     * where `@LATEST_VERSION@` is the token name to pass to this method.
      *
      * The files placed under the `projectDir/buildSrc` are excluded from the replacements.
      * This is done so, as the `buildSrc` files are typically copied over from the parent

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
@@ -104,6 +104,8 @@ public class GradleProjectSetup internal constructor(
     internal var addPluginUnderTestClasspath = false
         private set
 
+    internal var replacements: MutableSet<Replacement> = HashSet()
+
     /**
      * Sets the name of the resource directory and the predicate which accepts the files
      * from the specified directory for copying to the project to be created.
@@ -259,6 +261,22 @@ public class GradleProjectSetup internal constructor(
      */
     public fun withOptions(list: Iterable<String>): GradleProjectSetup {
         this.arguments = arguments.withOptions(list)
+        return this
+    }
+
+    /**
+     * Upon building the `GradleProject`, traverses through the resulting project directory,
+     * and replace all occurrences of the [token] with the passed [replacement] value.
+     *
+     * In text, token name must be framed with `@` symbols:
+     *```
+     *      The latest version of the library is @LATEST_VERSION@.
+     * ```
+     * where `LATEST_VERSION` is the token name to pass to this method.
+     */
+    public fun replace(token: String, replacement: String): GradleProjectSetup {
+        val r = Replacement(token, replacement)
+        this.replacements.add(r)
         return this
     }
 

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
@@ -26,7 +26,6 @@
 
 package io.spine.tools.gradle.testing
 
-import com.google.common.base.Preconditions.checkArgument
 import java.io.File
 
 /**
@@ -62,16 +61,12 @@ public class Replacement(public val token: String, public val value: String) {
     }
 
     private fun ensureFileAndExists(file: File) {
-        checkArgument(
-            file.exists(),
-            "`Replacement` requires an existing file, but none found at `%s`.",
-            file.absolutePath
-        )
-        checkArgument(
-            !file.isDirectory,
-            "`Replacement` cannot be launched in a directory `%s`. " +
-                    "Please pass a single file instead.",
-            file.absolutePath
-        )
+        require(file.exists()) {
+            "`Replacement` requires an existing file, but none found at `${file.absolutePath}`."
+        }
+        require(!file.isDirectory) {
+            "`Replacement` cannot be launched in a directory `${file.absolutePath}`. " +
+                    "Please pass a single file instead."
+        }
     }
 }

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle.testing
+
+import java.io.File
+
+/**
+ * A replacement to be made in a text.
+ *
+ * Scans the text for the occurrences of the formatted token, such as `@MY_TOKEN@`,
+ * and replaces them with the passed text value.
+ *
+ * @param token the name of the token, without `@` symbols
+ * @param value the value to replace the token occurrences to; may be blank
+ */
+public class Replacement(token: String, public val value: String) {
+
+    private val token: String
+
+    init {
+        require(token.isNotBlank())
+        this.token = token
+    }
+
+    /**
+     * Returns the token formatted as used in the text, in which the replacement will take place.
+     *
+     * Example:
+     * ```
+     *      Replacement("VERSION", ...).token() // -> returns "@VERSION@"
+     * ```
+     */
+    internal fun token(): String {
+        return "@$token@"
+    }
+
+    /**
+     * Replaces all occurrences of [token][token]
+     */
+    public fun replaceIn(file: File) {
+        val original = file.readText()
+        val modified = original.replace(token(), value)
+        if (modified != original) {
+            file.writeText(modified)
+        }
+    }
+}

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
@@ -61,9 +61,12 @@ public class Replacement(token: String, public val value: String) {
     /**
      * Replaces all occurrences of [token][token].
      */
-    public fun replaceIn(file: File) {
-        if(file.isDirectory) {
-            replaceInDir(file)
+    public fun replaceIn(file: File, excludeFolder: File? = null) {
+        if (file.isDirectory) {
+            replaceInDir(file, excludeFolder)
+            return
+        }
+        if (!shouldReplace(file, excludeFolder)) {
             return
         }
         val original = file.readText()
@@ -73,12 +76,21 @@ public class Replacement(token: String, public val value: String) {
         }
     }
 
-    //TODO:2021-12-30:alex.tymchenko: exclude `buildSrc` by pattern!
-    private fun replaceInDir(file: File) {
+    private fun replaceInDir(file: File, excludeFolder: File? = null) {
         file.walk()
             .filter { f -> !f.isDirectory }
+            .filter { f ->
+                shouldReplace(f, excludeFolder)
+            }
             .forEach { f ->
                 replaceIn(f)
             }
     }
+
+    private fun shouldReplace(f: File, excludeFolder: File?) =
+        if (excludeFolder == null) {
+            true
+        } else {
+            !f.absolutePath.startsWith(excludeFolder.absolutePath)
+        }
 }

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
@@ -59,13 +59,26 @@ public class Replacement(token: String, public val value: String) {
     }
 
     /**
-     * Replaces all occurrences of [token][token]
+     * Replaces all occurrences of [token][token].
      */
     public fun replaceIn(file: File) {
+        if(file.isDirectory) {
+            replaceInDir(file)
+            return
+        }
         val original = file.readText()
         val modified = original.replace(token(), value)
         if (modified != original) {
             file.writeText(modified)
         }
+    }
+
+    //TODO:2021-12-30:alex.tymchenko: exclude `buildSrc` by pattern!
+    private fun replaceInDir(file: File) {
+        file.walk()
+            .filter { f -> !f.isDirectory }
+            .forEach { f ->
+                replaceIn(f)
+            }
     }
 }

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
@@ -71,7 +71,7 @@ public class Replacement(token: String, public val value: String) {
             replaceInDir(file, excludeFolder)
             return
         }
-        if (!shouldReplace(file, excludeFolder)) {
+        if (file.isIn(excludeFolder)) {
             return
         }
         val original = file.readText()
@@ -84,18 +84,21 @@ public class Replacement(token: String, public val value: String) {
     private fun replaceInDir(file: File, excludeFolder: File? = null) {
         file.walk()
             .filter { f -> !f.isDirectory }
-            .filter { f ->
-                shouldReplace(f, excludeFolder)
-            }
+            .filter { f -> !f.isIn(excludeFolder) }
             .forEach { f ->
                 replaceIn(f)
             }
     }
 
-    private fun shouldReplace(f: File, excludeFolder: File?) =
-        if (excludeFolder == null) {
-            true
+    /**
+     * Tells whether the file resides in the [folder].
+     *
+     * If the [folder] is `null`, returns `false`.
+     */
+    private fun File.isIn(folder: File?) =
+        if(folder == null) {
+            false
         } else {
-            !f.absolutePath.startsWith(excludeFolder.absolutePath)
+            this.absolutePath.startsWith(folder.absolutePath)
         }
 }

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
@@ -60,6 +60,11 @@ public class Replacement(token: String, public val value: String) {
 
     /**
      * Replaces all occurrences of [token][token].
+     *
+     * If the passed [file] is a folder, the occurrences are replaced in all files which reside
+     * in this folder and its sub-folders recursively.
+     *
+     * Optionally, allows to specify the folder, which files should be excluded from replacement.
      */
     public fun replaceIn(file: File, excludeFolder: File? = null) {
         if (file.isDirectory) {

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/Replacement.kt
@@ -32,31 +32,19 @@ import java.io.File
 /**
  * A replacement to be made in a text.
  *
- * Scans the text for the occurrences of the formatted token, such as `@MY_TOKEN@`,
+ * Scans the text for the occurrences of the token, such as `@MY_TOKEN@`,
  * and replaces them with the passed text value.
  *
- * @param token the name of the token, without `@` symbols
+ * This type uses the token names as-is. It is a responsibility of callers to provide
+ * the correct name for the token with the respect of the format they consider to be legit.
+ *
+ * @param token the name of the token
  * @param value the value to replace the token occurrences to; may be blank
  */
-public class Replacement(token: String, public val value: String) {
-
-    private val token: String
+public class Replacement(public val token: String, public val value: String) {
 
     init {
         require(token.isNotBlank())
-        this.token = token
-    }
-
-    /**
-     * Returns the token formatted as used in the text, in which the replacement will take place.
-     *
-     * Example:
-     * ```
-     *      Replacement("VERSION", ...).token() // -> returns "@VERSION@"
-     * ```
-     */
-    internal fun token(): String {
-        return "@$token@"
     }
 
     /**
@@ -67,7 +55,7 @@ public class Replacement(token: String, public val value: String) {
     public fun replaceIn(file: File) {
         ensureFileAndExists(file)
         val original = file.readText()
-        val modified = original.replace(token(), value)
+        val modified = original.replace(token, value)
         if (modified != original) {
             file.writeText(modified)
         }

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/GradleProjectTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/GradleProjectTest.kt
@@ -90,11 +90,16 @@ class `'GradleProject' should` {
         assertThat(buildScript.readText())
             .contains(replacement)
 
-        val someTextFile = projectDir
+        val noReplacementFile = projectDir
             .resolve("buildSrc")
             .resolve("no-replacement.txt")
 
-        assertThat(someTextFile.readText())
+        assertThat(noReplacementFile.readText())
             .doesNotContain(replacement)
+
+        val replacementFile = projectDir
+            .resolve("src/main/java/acme/replacement.txt")
+        assertThat(replacementFile.readText())
+            .contains(replacement)
     }
 }

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/GradleProjectTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/GradleProjectTest.kt
@@ -26,6 +26,7 @@
 package io.spine.tools.gragle.testing
 
 import com.google.common.truth.Truth.assertThat
+import io.spine.base.Identifier
 import io.spine.tools.gradle.task.JavaTaskName.Companion.compileJava
 import io.spine.tools.gradle.testing.GradleProject
 import io.spine.tools.gradle.testing.GradleProjectSetup
@@ -76,5 +77,24 @@ class `'GradleProject' should` {
 
         assertThat(compileTask!!.outcome)
             .isEqualTo(TaskOutcome.FAILED)
+    }
+
+    @Test
+    fun `replace tokens in the build files, but exclude the 'buildSrc' folder`() {
+        val replacement = Identifier.newUuid()
+        setup.fromResources(origin)
+            .replace("TEST_TOKEN", replacement)
+            .create()
+
+        val buildScript = projectDir.resolve("build.gradle.kts")
+        assertThat(buildScript.readText())
+            .contains(replacement)
+
+        val someTextFile = projectDir
+            .resolve("buildSrc")
+            .resolve("no-replacement.txt")
+
+        assertThat(someTextFile.readText())
+            .doesNotContain(replacement)
     }
 }

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
@@ -93,10 +93,8 @@ class `'Replacement' should` {
                 .isEqualTo(expected)
         }
     }
-
-    companion object {
-        const val TOKEN_NAME = "@TEST_TOKEN@"
-        const val TEXT = "This is a `$TOKEN_NAME` which should be replaced with " +
-                "`$TOKEN_NAME`. \n\n\n And this `@TEST@ should remain the same."
-    }
 }
+
+private const val TOKEN_NAME = "@TEST_TOKEN@"
+private const val TEXT = "This is a `$TOKEN_NAME` which should be replaced with " +
+        "`$TOKEN_NAME`. \n\n\n And this `@TEST@ should remain the same."

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
@@ -124,8 +124,8 @@ class `'Replacement' should` {
 
         private val random: Random = SecureRandom()
 
-        val TOKEN_NAME = "TEST_TOKEN"
-        val TEXT = "This is a `@$TOKEN_NAME@` which should be replaced with " +
+        const val TOKEN_NAME = "TEST_TOKEN"
+        const val TEXT = "This is a `@$TOKEN_NAME@` which should be replaced with " +
                 "`@$TOKEN_NAME@`. \n\n\n And this `@TEST@ should remain the same."
 
         /**

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gragle.testing
+
+import com.google.common.truth.Truth.assertThat
+import io.spine.tools.gradle.testing.Replacement
+import java.io.File
+import java.nio.file.Path
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+
+class `'Replacement' should` {
+
+    private lateinit var folder: File
+
+    @BeforeEach
+    fun setUp(@TempDir tempDir: Path) {
+        folder = tempDir.toFile()
+    }
+
+    @Test
+    fun `frame the token name with '@' symbols`() {
+        val original = "mytoken"
+        val actual = Replacement(original, "").token()
+        assertThat(actual)
+            .isEqualTo("@$original@")
+    }
+
+    @Test
+    fun `not allow empty tokens`() {
+        assertThrows<IllegalArgumentException> { Replacement("", "value")  }
+    }
+
+    @Test
+    fun `allow empty values-to-replace-with`() {
+        assertThat(Replacement("sometoken", "").value)
+            .isEmpty()
+    }
+
+    @Test
+    fun `replace all token occurrences in file`() {
+        val file = folder.resolve("replace_all.test")
+        val token = "TEST_TOKEN"
+        val original = "This is a `@$token@` which should be replaced with " +
+                "`@$token@`. And this `@TEST@ should remain the same."
+        file.writeText(original)
+
+        val value = "replaced"
+        Replacement(token, value).replaceIn(file)
+
+        val actual = file.readText()
+        val expected = original.replace("@$token@", value)
+        assertThat(actual)
+            .isEqualTo(expected)
+    }
+}

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
@@ -27,13 +27,9 @@
 package io.spine.tools.gragle.testing
 
 import com.google.common.truth.Truth.assertThat
-import io.spine.base.Identifier
 import io.spine.tools.gradle.testing.Replacement
 import java.io.File
 import java.nio.file.Path
-import java.security.SecureRandom
-import java.util.*
-import kotlin.collections.ArrayList
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -59,7 +55,7 @@ class `'Replacement' should` {
 
     @Test
     fun `not allow empty tokens`() {
-        assertThrows<IllegalArgumentException> { Replacement("", "value")  }
+        assertThrows<IllegalArgumentException> { Replacement("", "value") }
     }
 
     @Test
@@ -73,100 +69,26 @@ class `'Replacement' should` {
 
         @Test
         fun `in a file`() {
-            val ref = TestData(folder, TEXT)
+            val file = folder.resolve("replace_all.test")
+            file.writeText(TEXT)
             val value = "replaced"
-            Replacement(TOKEN_NAME, value).replaceIn(ref.file)
-            ref.assertReplaced(TOKEN_NAME, value)
+            Replacement(TOKEN_NAME, value).replaceIn(file)
+            file.assertReplaced(TOKEN_NAME, value)
         }
 
-        @Test
-        fun `in files residing in a folder and its subfolders`() {
-            val refs = generateFiles(folder)
-
-            val value = "recursively-replaced"
-            Replacement(TOKEN_NAME, value)
-                .replaceIn(folder)
-            for (ref in refs) {
-                ref.assertReplaced(TOKEN_NAME, value)
-            }
+        private fun File.assertReplaced(token: String, value: String) {
+            val text = this.readText()
+            val expected = TEXT.replace("@$token@", value)
+            assertThat(text)
+                .isEqualTo(expected)
         }
-
-        @Test
-        fun `in all files in the folder recursively, excluding some folder`() {
-            val toReplace = generateFiles(folder)
-
-            val excludedFolder = folder.resolve("untouchable")
-            excludedFolder.mkdirs()
-            val toExclude = generateFiles(excludedFolder)
-
-            val value = "recursively-replaced"
-            Replacement(TOKEN_NAME, value)
-                .replaceIn(folder, excludedFolder)
-
-            for (ref in toReplace) {
-                ref.assertReplaced(TOKEN_NAME, value)
-            }
-            for (ref in toExclude) {
-                ref.assertNotReplaced()
-            }
-        }
-    }
-
-    private fun generateFiles(folder: File): ArrayList<TestData> {
-        val refs = ArrayList<TestData>()
-        for (i in 0..10) {
-            refs.add(TestData(folder, TEXT))
-        }
-        return refs
     }
 
     companion object {
-
-        private val random: Random = SecureRandom()
 
         const val TOKEN_NAME = "TEST_TOKEN"
         const val TEXT = "This is a `@$TOKEN_NAME@` which should be replaced with " +
                 "`@$TOKEN_NAME@`. \n\n\n And this `@TEST@ should remain the same."
 
-        /**
-         * Creates a test file with the specified [content] inside the passed [parentFolder].
-         *
-         * Prior to creating the file, establishes some number of sub-folders, to which the file
-         * is put. The number lies between zero and two.
-         *
-         * The name of the file and the names of folders are based on UUIDs.
-         */
-        class TestData(private val parentFolder: File, val content: String) {
-
-            val file: File
-
-            init {
-                val randomValue = Identifier.newUuid()
-                val nestingLevel = random.nextInt(3)
-
-                var folder = parentFolder
-                for(i in 0..nestingLevel) {
-                    val subfolder = folder.resolve("nested_${Identifier.newUuid()}")
-                    subfolder.mkdirs()
-                    folder = subfolder
-                }
-
-                file = folder.resolve("replace_all_${randomValue}.test")
-                file.writeText(content)
-            }
-
-            fun assertReplaced(token: String, value: String) {
-                val text = file.readText()
-                val expected = content.replace("@$token@", value)
-                assertThat(text)
-                    .isEqualTo(expected)
-            }
-
-            fun assertNotReplaced() {
-                val text = file.readText()
-                assertThat(text)
-                    .isEqualTo(content)
-            }
-        }
     }
 }

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
@@ -81,10 +81,8 @@ class `'Replacement' should` {
 
         @Test
         fun `in files residing in a folder and its subfolders`() {
-            val refs = ArrayList<TestData>()
-            for(i in 0..10) {
-                refs.add(TestData(folder, TEXT))
-            }
+            val refs = generateFiles(folder)
+
             val value = "recursively-replaced"
             Replacement(TOKEN_NAME, value)
                 .replaceIn(folder)
@@ -92,6 +90,34 @@ class `'Replacement' should` {
                 ref.assertReplaced(TOKEN_NAME, value)
             }
         }
+
+        @Test
+        fun `in all files in the folder recursively, excluding some folder`() {
+            val toReplace = generateFiles(folder)
+
+            val excludedFolder = folder.resolve("untouchable")
+            excludedFolder.mkdirs()
+            val toExclude = generateFiles(excludedFolder)
+
+            val value = "recursively-replaced"
+            Replacement(TOKEN_NAME, value)
+                .replaceIn(folder, excludedFolder)
+
+            for (ref in toReplace) {
+                ref.assertReplaced(TOKEN_NAME, value)
+            }
+            for (ref in toExclude) {
+                ref.assertNotReplaced()
+            }
+        }
+    }
+
+    private fun generateFiles(folder: File): ArrayList<TestData> {
+        val refs = ArrayList<TestData>()
+        for (i in 0..10) {
+            refs.add(TestData(folder, TEXT))
+        }
+        return refs
     }
 
     companion object {
@@ -134,6 +160,12 @@ class `'Replacement' should` {
                 val expected = content.replace("@$token@", value)
                 assertThat(text)
                     .isEqualTo(expected)
+            }
+
+            fun assertNotReplaced() {
+                val text = file.readText()
+                assertThat(text)
+                    .isEqualTo(content)
             }
         }
     }

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
@@ -88,7 +88,7 @@ class `'Replacement' should` {
 
         private fun File.assertReplaced(token: String, value: String) {
             val text = this.readText()
-            val expected = TEXT.replace("@$token@", value)
+            val expected = TEXT.replace(token, value)
             assertThat(text)
                 .isEqualTo(expected)
         }

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
@@ -46,14 +46,6 @@ class `'Replacement' should` {
     }
 
     @Test
-    fun `frame the token name with '@' symbols`() {
-        val original = "mytoken"
-        val actual = Replacement(original, "").token()
-        assertThat(actual)
-            .isEqualTo("@$original@")
-    }
-
-    @Test
     fun `not allow empty tokens`() {
         assertThrows<IllegalArgumentException> { Replacement("", "value") }
     }
@@ -62,6 +54,24 @@ class `'Replacement' should` {
     fun `allow empty values-to-replace-with`() {
         assertThat(Replacement("sometoken", "").value)
             .isEmpty()
+    }
+
+    @Nested
+    inner class `not accept` {
+
+        @Test
+        fun `folder as the 'replaceIn' argument`() {
+            assertThrows<IllegalArgumentException> {
+                Replacement("some-token", "").replaceIn(folder)
+            }
+        }
+
+        @Test
+        fun `non-existing file as the 'replaceIn' argument`() {
+            assertThrows<IllegalArgumentException> {
+                Replacement("some-token", "").replaceIn(folder.resolve("foobar"))
+            }
+        }
     }
 
     @Nested
@@ -85,10 +95,8 @@ class `'Replacement' should` {
     }
 
     companion object {
-
-        const val TOKEN_NAME = "TEST_TOKEN"
-        const val TEXT = "This is a `@$TOKEN_NAME@` which should be replaced with " +
-                "`@$TOKEN_NAME@`. \n\n\n And this `@TEST@ should remain the same."
-
+        const val TOKEN_NAME = "@TEST_TOKEN@"
+        const val TEXT = "This is a `$TOKEN_NAME` which should be replaced with " +
+                "`$TOKEN_NAME`. \n\n\n And this `@TEST@ should remain the same."
     }
 }

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gragle/testing/ReplacementTest.kt
@@ -136,7 +136,7 @@ class `'Replacement' should` {
          *
          * The name of the file and the names of folders are based on UUIDs.
          */
-        class TestData(val parentFolder: File, val content: String) {
+        class TestData(private val parentFolder: File, val content: String) {
 
             val file: File
 

--- a/plugin-testlib/src/test/resources/gradle_project_test/build.gradle.kts
+++ b/plugin-testlib/src/test/resources/gradle_project_test/build.gradle.kts
@@ -30,3 +30,6 @@ apply(plugin = "java")
 // NOTE: this file is copied from the root project in the test setup.
 apply(from = "$rootDir/test-env.gradle")
 apply(from = "$enclosingRootDir/version.gradle.kts")
+
+// This comment has a token named @TEST_TOKEN@ which should be replaced.
+// It is used in `GradleProjectTest`.

--- a/plugin-testlib/src/test/resources/gradle_project_test/buildSrc/no-replacement.txt
+++ b/plugin-testlib/src/test/resources/gradle_project_test/buildSrc/no-replacement.txt
@@ -1,0 +1,4 @@
+// This comment has a token named @TEST_TOKEN@ which should NOT be replaced, as it is a part
+// of the `buildSrc` folder, which is excluded from the replacement.
+//
+// This file is used in `GradleProjectTest`.

--- a/plugin-testlib/src/test/resources/gradle_project_test/src/main/java/acme/replacement.txt
+++ b/plugin-testlib/src/test/resources/gradle_project_test/src/main/java/acme/replacement.txt
@@ -1,0 +1,2 @@
+// This comment has a token named @TEST_TOKEN@ which should be replaced.
+// It is used in `GradleProjectTest`.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.86</version>
+<version>2.0.0-SNAPSHOT.87</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,4 +25,4 @@
  */
 
 val baseVersion: String by extra("2.0.0-SNAPSHOT.80")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.86")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.87")


### PR DESCRIPTION
This changeset brings the functionality on additional processing of files involved into `GradleProject` setup.

In particular, it is now possble to replace the tokens formatted like `@my-token@` with some string values:

```kotlin
GradleProject.setupAt(someDir)
    // ....
    .replace("my-token", "some value")  // Finds all `@my-token@` strings and turns them into `some value`.

```

The contents of `projectDir/buildSrc` are excluded from the replacement process. Such a procedure would make not much sense, as our `buildSrc` files are usually copies of the "real" `buildSrc` files from the parent project. Therefore, they hardly contain any tokens.

The library version is set to `2.0.0-SNAPSHOT.87`.