### PR TITLE
Add `Language` types

### DIFF
--- a/buildSrc/src/main/kotlin/pmd-settings.gradle.kts
+++ b/buildSrc/src/main/kotlin/pmd-settings.gradle.kts
@@ -41,11 +41,9 @@ pmd {
     // Disable the default rule set to use the custom rules (see below).
     ruleSets = listOf()
 
-    // Load PMD settings from a file in `buildSrc/resources/`.
-    val classLoader = Pmd.javaClass.classLoader
-    val settingsResource = classLoader.getResource("pmd.xml")!!
-    val pmdSettings: String = settingsResource.readText()
-    val textResource: TextResource = resources.text.fromString(pmdSettings)
+    // Load PMD settings.
+    val pmdSettings = file("$rootDir/config/quality/pmd.xml")
+    val textResource: TextResource = resources.text.fromFile(pmdSettings)
     ruleSetConfig = textResource
 
     reportsDir = file("build/reports/pmd")

--- a/license-report.md
+++ b/license-report.md
@@ -457,7 +457,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 19:56:45 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 21:17:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -971,7 +971,7 @@ This report was generated on **Tue Jan 11 19:56:45 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 19:56:45 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 21:17:57 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1401,4 +1401,4 @@ This report was generated on **Tue Jan 11 19:56:45 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 19:56:46 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 21:17:58 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14,11 +14,11 @@
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -51,6 +51,9 @@
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
@@ -154,11 +157,11 @@
 1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -194,6 +197,9 @@
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.2.
@@ -451,12 +457,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 19:56:45 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -474,11 +480,11 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -514,6 +520,9 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
@@ -662,11 +671,11 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -702,6 +711,9 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.2.
@@ -959,12 +971,12 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 19:56:45 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -978,11 +990,11 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1007,6 +1019,9 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
@@ -1102,11 +1117,11 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1134,6 +1149,9 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.2.
@@ -1383,4 +1401,4 @@ This report was generated on **Mon Jan 10 15:08:10 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 10 15:08:11 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 19:56:46 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.88</version>
+<version>2.0.0-SNAPSHOT.89</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -44,13 +44,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.80</version>
+    <version>2.0.0-SNAPSHOT.85</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.80</version>
+    <version>2.0.0-SNAPSHOT.85</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
+++ b/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.code
+
+import io.spine.io.Glob
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * A programming language or a specific syntax.
+ *
+ * For example, `"Java"`, `"Python 3.x"`, etc.
+ */
+public abstract class Language internal constructor(
+
+    /**
+     * Label to distinguish the language.
+     */
+    public val name: String,
+
+    /**
+     * Extensions of source code files on this language with or without the leading dot.
+     *
+     * Some languages may have more than one type of files, e.g. header files ".h" for C source
+     * code files (".c"). Also, conventions for some languages allow alternative extensions,
+     * e.g. ".cc" and ".cpp" for C++.
+     *
+     * The passed values are converted to lower case.
+     */
+    fileExtensions: List<String>,
+
+    /**
+     * Patterns one of which a language source file must match.
+     *
+     * If not specified, patterns matching [fileExtensions] will be created.
+     */
+    filePatterns: List<Glob>? = null
+) {
+
+    /**
+     * The extension of source code files in this language without the leading dot.
+     */
+    public val fileExtensions: List<String>
+
+    /**
+     * Pattern which source code files must match.
+     */
+    private val filePatterns: List<Glob>
+
+    init {
+        this.fileExtensions = fileExtensions
+            .map { it.replaceFirst(".", "") }
+            .map { it.lowercase() }
+            .toMutableList()
+            .sorted()
+        this.filePatterns = filePatterns ?: this.fileExtensions.map(Glob::extension)
+    }
+
+    /**
+     * Creates a syntactically valid one-line comment in this language.
+     *
+     * @param line
+     *          the contents of the comment
+     * @return a line which can be safely inserted into a code file.
+     */
+    public abstract fun comment(line: String): String
+
+    /**
+     * Checks if the given file is a code file in this language.
+     *
+     * If the passed instance is a directory, rather than a file, returns `false`.
+     */
+    public fun matches(file: File): Boolean = matches(file.toPath())
+
+    /**
+     * Checks if the given file is a code file in this language.
+     *
+     * If the passed instance is a directory, rather than a file, returns `false`.
+     */
+    public fun matches(file: Path): Boolean = filePatterns.any { it.matches(file) }
+
+    /**
+     * Returns the name of the language.
+     */
+    override fun toString(): String = name
+}
+
+/**
+ * A C-like language.
+ *
+ * Supports double-slash comments (`// <comment body>`).
+ */
+public class SlashCommentLanguage(
+    name: String,
+    fileExtensions: List<String>
+) : Language(name, fileExtensions) {
+
+    override fun comment(line: String): String = "// $line"
+}
+
+/**
+ * A collection of commonly used [Language]s.
+ *
+ * If this prepared set is not enough, users are encouraged to create custom [Language] types
+ * by either extending the class directly, or using one of its existing subtypes, such as
+ * [SlashCommentLanguage].
+ */
+public object CommonLanguages {
+
+    /**
+     * Any language will do.
+     *
+     * This instance indicates that any programming language can be accepted.
+     *
+     * Intended to be used for filtering source files by language via file name conventions.
+     * If no filtering required, but a [Language] is needed, use `CommonLanguages.any`.
+     *
+     * Does not support [comments][Language.comment].
+     */
+    @get:JvmName("any")
+    @JvmStatic
+    public val any: Language = object : Language("any language", listOf(""), listOf(Glob.any)) {
+        override fun comment(line: String): String {
+            throw UnsupportedOperationException("`$name` does not support comments.")
+        }
+    }
+
+    @get:JvmName("kotlin")
+    @JvmStatic
+    public val Kotlin: Language = SlashCommentLanguage("Kotlin", listOf("kt"))
+
+    @get:JvmName("java")
+    @JvmStatic
+    public val Java: Language = SlashCommentLanguage("Java", listOf("java"))
+
+    @get:JvmName("javaScript")
+    @JvmStatic
+    public val JavaScript: Language = SlashCommentLanguage("JavaScript", listOf("js"))
+}

--- a/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
+++ b/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
@@ -51,14 +51,14 @@ public abstract class Language internal constructor(
      *
      * The passed values are converted to lower case.
      */
-    fileExtensions: List<String>,
+    fileExtensions: Iterable<String>,
 
     /**
      * Patterns one of which a language source file must match.
      *
      * If not specified, patterns matching [fileExtensions] will be created.
      */
-    filePatterns: List<Glob>? = null
+    filePattern: Glob? = null
 ) {
 
     /**
@@ -69,7 +69,7 @@ public abstract class Language internal constructor(
     /**
      * Pattern which source code files must match.
      */
-    private val filePatterns: List<Glob>
+    private val filePattern: Glob
 
     init {
         this.fileExtensions = fileExtensions
@@ -77,7 +77,7 @@ public abstract class Language internal constructor(
             .map { it.lowercase() }
             .toMutableList()
             .sorted()
-        this.filePatterns = filePatterns ?: this.fileExtensions.map(Glob::extension)
+        this.filePattern = filePattern ?: Glob.extension(this.fileExtensions)
     }
 
     /**
@@ -101,7 +101,7 @@ public abstract class Language internal constructor(
      *
      * If the passed instance is a directory, rather than a file, returns `false`.
      */
-    public fun matches(file: Path): Boolean = filePatterns.any { it.matches(file) }
+    public fun matches(file: Path): Boolean = filePattern.matches(file)
 
     /**
      * Returns the name of the language.
@@ -116,7 +116,7 @@ public abstract class Language internal constructor(
  */
 public class SlashCommentLanguage(
     name: String,
-    fileExtensions: List<String>
+    fileExtensions: Iterable<String>
 ) : Language(name, fileExtensions) {
 
     override fun comment(line: String): String = "// $line"
@@ -143,7 +143,7 @@ public object CommonLanguages {
      */
     @get:JvmName("any")
     @JvmStatic
-    public val any: Language = object : Language("any language", listOf(""), listOf(Glob.any)) {
+    public val any: Language = object : Language("any language", listOf(""), Glob.any) {
         override fun comment(line: String): String {
             throw UnsupportedOperationException("`$name` does not support comments.")
         }

--- a/tool-base/src/test/java/io/spine/tools/code/LanguageTest.java
+++ b/tool-base/src/test/java/io/spine/tools/code/LanguageTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.code;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+@DisplayName("`Language` Java API should expose")
+class LanguageTest {
+
+    @Test
+    @DisplayName("`any()` language")
+    void anyLang() {
+        assertMatches(CommonLanguages.any(), "anything_will.do");
+    }
+
+    @Test
+    void kotlin() {
+        assertMatches(CommonLanguages.kotlin(), "my.kt");
+    }
+
+    @Test
+    void java() {
+        assertMatches(CommonLanguages.java(), "pure.java");
+    }
+
+    @Test
+    void javaScript() {
+        assertMatches(CommonLanguages.javaScript(), "wild.js");
+    }
+
+    private static void assertMatches(Language language, String file) {
+        var path = Paths.get(file);
+        assertWithMessage("The language `%s` should recognize the file `%s`.", language, file)
+                .that(language.matches(path))
+                .isTrue();
+    }
+}

--- a/tool-base/src/test/kotlin/io/spine/tools/code/LanguageTest.kt
+++ b/tool-base/src/test/kotlin/io/spine/tools/code/LanguageTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.code
+
+import com.google.common.truth.Truth.assertThat
+import io.spine.tools.code.CommonLanguages.Java
+import io.spine.tools.code.CommonLanguages.JavaScript
+import io.spine.tools.code.CommonLanguages.Kotlin
+import io.spine.tools.code.CommonLanguages.any
+import java.io.File
+import java.nio.file.Paths
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class `'Language' should` {
+
+    @Test
+    fun `return its name in the string form`() {
+        assertThat(Kotlin.toString()).isEqualTo("Kotlin")
+    }
+
+    @Test
+    fun `expose file pattern`() {
+        assertThat(Kotlin.fileExtensions).containsExactly("kt")
+        assertThat(Brainfuck().fileExtensions).containsExactly("b", "bf")
+    }
+
+    @Test
+    fun `format a test line as comments`() {
+        assertThat(Java.comment("Hey!")).isEqualTo("// Hey!")
+    }
+
+    @Test
+    fun `filter files by their extension`() {
+        // Passing the directory, rather than file.
+        assertThat(JavaScript.matches(File("Windows"))).isFalse()
+
+        // Passing file with extension.
+        assertThat(JavaScript.matches(File("safari.swift"))).isFalse()
+        
+        assertThat(JavaScript.matches(File("mozilla.js"))).isTrue()
+    }
+
+    @Test
+    fun `throw 'UnsupportedOperationException' for the synthetic 'any' language`() {
+        assertThrows<UnsupportedOperationException> { any.comment("kaboom") }
+    }
+
+    @Nested
+    inner class `support more than one file extension` {
+
+        private val cpp = SlashCommentLanguage("C++", listOf(".HPP", ".cc", ".CPP", "h"))
+
+        @Test
+        fun `sorting and lower-casing them on initialization`() {
+            assertThat(cpp.fileExtensions).containsExactly("cc", "cpp", "h", "hpp")
+        }
+
+        @Test
+        fun `matching all kinds of files`() {
+            assertMatches("1.cc")
+            assertMatches("2.h")
+            assertMatches("3.hpp")
+            assertMatches("4.cpp")
+        }
+
+        private fun assertMatches(file: String) {
+            val path = Paths.get(file)
+            assertThat(cpp.matches(path)).isTrue()
+        }
+    }
+}
+
+private class Brainfuck: Language("Brainfuck", listOf(".b", ".bf")) {
+    override fun comment(line: String): String = "[ $line ]"
+}

--- a/tool-base/src/test/kotlin/io/spine/tools/code/LanguageTest.kt
+++ b/tool-base/src/test/kotlin/io/spine/tools/code/LanguageTest.kt
@@ -96,6 +96,10 @@ class `'Language' should` {
     }
 }
 
+/**
+ * [Brainfuck](https://en.wikipedia.org/wiki/Brainfuck) is an esoteric programming language
+ * created in 1993 by Urban Müller.
+ */
 private class Brainfuck: Language("Brainfuck", listOf(".b", ".bf")) {
     override fun comment(line: String): String = "[ $line ]"
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,5 +24,5 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val baseVersion: String by extra("2.0.0-SNAPSHOT.83")
+val baseVersion: String by extra("2.0.0-SNAPSHOT.84")
 val versionToPublish: String by extra("2.0.0-SNAPSHOT.89")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,5 +24,5 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val baseVersion: String by extra("2.0.0-SNAPSHOT.80")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.88")
+val baseVersion: String by extra("2.0.0-SNAPSHOT.83")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.89")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,5 +24,5 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val baseVersion: String by extra("2.0.0-SNAPSHOT.84")
+val baseVersion: String by extra("2.0.0-SNAPSHOT.85")
 val versionToPublish: String by extra("2.0.0-SNAPSHOT.89")


### PR DESCRIPTION
This PR introduces the `Language` and derived types, which originate from ProtoData project. These types will be used in language-specific settings of Model Compiler, and presumably other dev. tools provided by the Spine framework.

The `Language` and derived classes were extended in the following ways:
  * A `Language` can have more than one file extension. This is useful for languages like C and C++.
  * File extensions exposed by a `Language` are now alphabetically sorted (to ease the diagnostics when debugging).
  * A `Language` can be initialized with `Glob` passed directly. If `filePattern` constructor parameter is not specified, the `filePattern` property will be created using the passed file extensions.
  * And vice versa, it is possible not to send any file extensions _but_ send a `filePattern` parameter instead. Such a trick is used for the synthetic language `any`.
