### PR TITLE
Use actual space symbols when specifying the indentation for JavaPoet

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.108`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.109`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -470,12 +470,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 06 13:06:28 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 06 14:09:04 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.108`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.109`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -997,12 +997,12 @@ This report was generated on **Thu Oct 06 13:06:28 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 06 13:06:29 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 06 14:09:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.108`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.109`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1440,4 +1440,4 @@ This report was generated on **Thu Oct 06 13:06:29 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 06 13:06:30 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 06 14:09:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.108</version>
+<version>2.0.0-SNAPSHOT.109</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tool-base/src/main/java/io/spine/tools/java/code/TypeSpecWriter.java
+++ b/tool-base/src/main/java/io/spine/tools/java/code/TypeSpecWriter.java
@@ -68,7 +68,7 @@ public final class TypeSpecWriter implements Logging {
             _debug().log("Writing `%s.java`.", className);
 
             var packageName = this.spec.packageName().value();
-            var indentLevel = String.valueOf(indent.level());
+            var indentLevel = indent.at(1).toString();
             var javaFile = JavaFile.builder(packageName, typeSpec)
                     .skipJavaLangImports(true)
                     .indent(indentLevel)

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,4 +25,4 @@
  */
 
 val baseVersion: String by extra("2.0.0-SNAPSHOT.108")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.108")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.109")


### PR DESCRIPTION
As it appears, we have to pass actual space symbols as an `indent(String)` argument when configuring JavaPoet's codegen.

This changeset does precisely that.