### PR TITLE
Add `kotlin` as `protoc` plugin

### DIFF
--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -96,7 +96,7 @@ jobs:
         )" > ${{ github.workspace }}/detekt.sarif.json
 
     # Uploads results to GitHub repository using the upload-sarif action
-    - uses: github/codeql-action/upload-sarif@v1
+    - uses: github/codeql-action/upload-sarif@v2
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: ${{ github.workspace }}/detekt.sarif.json

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -96,7 +96,7 @@ jobs:
         )" > ${{ github.workspace }}/detekt.sarif.json
 
     # Uploads results to GitHub repository using the upload-sarif action
-    - uses: github/codeql-action/upload-sarif@v2
+    - uses: github/codeql-action/upload-sarif@v1
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: ${{ github.workspace }}/detekt.sarif.json

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <list size="5">
-      <item index="0" class="java.lang.String" itemvalue="io.spine.core.Subscribe" />
-      <item index="1" class="java.lang.String" itemvalue="io.spine.server.aggregate.Apply" />
-      <item index="2" class="java.lang.String" itemvalue="io.spine.server.command.Assign" />
-      <item index="3" class="java.lang.String" itemvalue="io.spine.server.command.Command" />
-      <item index="4" class="java.lang.String" itemvalue="io.spine.server.event.React" />
+    <list size="6">
+      <item index="0" class="java.lang.String" itemvalue="com.google.auto.service.AutoService" />
+      <item index="1" class="java.lang.String" itemvalue="io.spine.core.Subscribe" />
+      <item index="2" class="java.lang.String" itemvalue="io.spine.server.aggregate.Apply" />
+      <item index="3" class="java.lang.String" itemvalue="io.spine.server.command.Assign" />
+      <item index="4" class="java.lang.String" itemvalue="io.spine.server.command.Command" />
+      <item index="5" class="java.lang.String" itemvalue="io.spine.server.event.React" />
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />

--- a/buildSrc/src/main/kotlin/deps-between-tasks.kt
+++ b/buildSrc/src/main/kotlin/deps-between-tasks.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+/**
+ * Configures the dependencies between third-party Gradle tasks
+ * and those defined via ProtoData and Spine Model Compiler.
+ *
+ * It is required in order to avoid warnings in build logs, detecting the undeclared
+ * usage of Spine-specific task output by other tasks,
+ * e.g. the output of `launchProtoDataMain` is used by `compileKotlin`.
+ */
+@Suppress("unused")
+fun Project.configureTaskDependencies() {
+
+    /**
+     * Creates a dependency between the Gradle task of *this* name
+     * onto the task with `taskName`.
+     *
+     * If either of tasks does not exist in the enclosing `Project`,
+     * this method does nothing.
+     *
+     * This extension is kept local to `configureTaskDependencies` extension
+     * to prevent its direct usage from outside.
+     */
+    fun String.dependOn(taskName: String) {
+        val whoDepends = this
+        val dependOntoTask: Task? = tasks.findByName(taskName)
+        dependOntoTask?.let {
+            tasks.findByName(whoDepends)?.dependsOn(it)
+        }
+    }
+
+    afterEvaluate {
+        "compileKotlin".dependOn("launchProtoDataMain")
+        "compileTestKotlin".dependOn("launchProtoDataTest")
+        "sourcesJar".dependOn("generateProto")
+        "sourcesJar".dependOn("launchProtoDataMain")
+        "sourcesJar".dependOn("createVersionFile")
+        "dokkaHtml".dependOn("generateProto")
+        "dokkaHtml".dependOn("launchProtoDataMain")
+        "dokkaJavadoc".dependOn("launchProtoDataMain")
+        "publishPluginJar".dependOn("createVersionFile")
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.21.7"
+    const val version       = "3.19.6"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/fs/LazyTempPath.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/fs/LazyTempPath.kt
@@ -54,17 +54,17 @@ class LazyTempPath(private val prefix: String) : Path {
             return tempPath
         }
 
-    override fun compareTo(other: Path?): Int = delegate.compareTo(other)
+    override fun compareTo(other: Path): Int = delegate.compareTo(other)
 
     override fun iterator(): MutableIterator<Path> = delegate.iterator()
 
     override fun register(
-        watcher: WatchService?,
-        events: Array<out WatchEvent.Kind<*>>?,
+        watcher: WatchService,
+        events: Array<out WatchEvent.Kind<*>>,
         vararg modifiers: WatchEvent.Modifier?
     ): WatchKey = delegate.register(watcher, events, *modifiers)
 
-    override fun register(watcher: WatchService?, vararg events: WatchEvent.Kind<*>?): WatchKey =
+    override fun register(watcher: WatchService, vararg events: WatchEvent.Kind<*>?): WatchKey =
         delegate.register(watcher, *events)
 
     override fun getFileSystem(): FileSystem = delegate.fileSystem

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/RepositoryExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/RepositoryExtensions.kt
@@ -42,7 +42,7 @@ import io.spine.internal.gradle.git.UserInfo
  * to "UpdateGitHubPages Plugin", and the email is derived from
  * the `FORMAL_GIT_HUB_PAGES_AUTHOR` environment variable.
  *
- * @throws GradleException if any of the environment variables described above
+ * @throws org.gradle.api.GradleException if any of the environment variables described above
  *         is not set.
  */
 internal fun Repository.Factory.forPublishingDocumentation(): Repository {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/Update.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/Update.kt
@@ -75,7 +75,7 @@ private abstract class UpdateDocumentation(
      * The value should not contain any leading or trailing file separators.
      *
      * The absolute path to the project's documentation is made by appending its
-     * name to the end, making `/[docsDestinationFolder]/[project.name]`.
+     * name to the end, making `/docsDestinationFolder/project.name`.
      */
     protected abstract val docsDestinationFolder: String
 
@@ -86,25 +86,29 @@ private abstract class UpdateDocumentation(
      */
     protected abstract val toolName: String
 
-    private val mostRecentFolder = File("${repository.location}/${docsDestinationFolder}/${project.name}")
+    private val mostRecentFolder by lazy {
+        File("${repository.location}/${docsDestinationFolder}/${project.name}")
+    }
 
     fun run() {
-        logger.debug("Update of the ${toolName} documentation for module `${project.name}` started.")
+        val module = project.name
+        logger.debug("Update of the $toolName documentation for module `$module` started.")
 
         val documentation = replaceMostRecentDocs()
         copyIntoVersionDir(documentation)
 
-        val updateMessage = "Update ${toolName} documentation for module `${project.name}` as for " +
-                "version ${project.version}"
+        val version = project.version
+        val updateMessage = "Update $toolName documentation for module `$module` as for " +
+                "version $version"
         repository.commitAllChanges(updateMessage)
 
-        logger.debug("Update of the ${toolName} documentation for `${project.name}` successfully finished.")
+        logger.debug("Update of the $toolName documentation for `$module` successfully finished.")
     }
 
     private fun replaceMostRecentDocs(): ConfigurableFileCollection {
         val generatedDocs = project.files(docsSourceFolder)
 
-        logger.debug("Replacing the most recent ${toolName} documentation in ${mostRecentFolder}.")
+        logger.debug("Replacing the most recent $toolName documentation in ${mostRecentFolder}.")
         copyDocs(generatedDocs, mostRecentFolder)
 
         return generatedDocs
@@ -121,7 +125,7 @@ private abstract class UpdateDocumentation(
     private fun copyIntoVersionDir(generatedDocs: ConfigurableFileCollection) {
         val versionedDocDir = File("$mostRecentFolder/v/${project.version}")
 
-        logger.debug("Storing the new version of ${toolName} documentation in `${versionedDocDir}.")
+        logger.debug("Storing the new version of $toolName documentation in `${versionedDocDir}.")
         copyDocs(generatedDocs, versionedDocDir)
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/protobuf/ProtoTaskExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/protobuf/ProtoTaskExtensions.kt
@@ -28,6 +28,8 @@ package io.spine.internal.gradle.protobuf
 
 import com.google.protobuf.gradle.GenerateProtoTask
 import java.io.File
+import java.lang.System.lineSeparator
+import org.gradle.api.Task
 import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.get
 
@@ -75,6 +77,8 @@ import org.gradle.kotlin.dsl.get
 @Suppress("unused")
 fun GenerateProtoTask.setup(generatedDir: String) {
 
+    builtins.create("kotlin")
+
     /**
      * Generate descriptor set files.
      */
@@ -86,27 +90,10 @@ fun GenerateProtoTask.setup(generatedDir: String) {
         includeSourceInfo = true
     }
 
-    /**
-     * Remove the code generated for Google Protobuf library types.
-     *
-     * Java code for the `com.google` package was generated because we wanted
-     * to have descriptors for all the types, including those from Google Protobuf library.
-     * We want all the descriptors so that they are included into the resources used by
-     * the `io.spine.type.KnownTypes` class.
-     *
-     * Now, as we have the descriptors _and_ excessive Java code, we delete it to avoid
-     * classes that duplicate those coming from Protobuf library JARs.
-     */
     doLast {
-        val comPackage = File("${generatedDir}/${ssn}/java/com")
-        val googlePackage = comPackage.resolve("google")
-
-        project.delete(googlePackage)
-
-        // We don't need an empty `com` package.
-        if (comPackage.exists() && comPackage.list()?.isEmpty() == true) {
-            project.delete(comPackage)
-        }
+        deleteComGoogle(generatedDir, ssn, "java")
+        deleteComGoogle(generatedDir, ssn, "kotlin")
+        suppressDeprecationsInKotlin(generatedDir, ssn)
     }
 
     /**
@@ -122,9 +109,62 @@ fun GenerateProtoTask.setup(generatedDir: String) {
 }
 
 /**
+ * Remove the code generated for Google Protobuf library types.
+ *
+ * Java code for the `com.google` package was generated because we wanted
+ * to have descriptors for all the types, including those from Google Protobuf library.
+ * We want all the descriptors so that they are included into the resources used by
+ * the `io.spine.type.KnownTypes` class.
+ *
+ * Now, as we have the descriptors _and_ excessive Java or Kotlin code, we delete it to avoid
+ * classes that duplicate those coming from Protobuf library JARs.
+ */
+private fun Task.deleteComGoogle(generatedDir: String, ssn: String, language: String) {
+    val comPackage = File("${generatedDir}/${ssn}/$language/com")
+    val googlePackage = comPackage.resolve("google")
+
+    project.delete(googlePackage)
+
+    // We don't need an empty `com` package.
+    if (comPackage.exists() && comPackage.list()?.isEmpty() == true) {
+        project.delete(comPackage)
+    }
+}
+
+/**
  * Obtains the name of the task `processResource` task for the given source set name.
  */
-fun processResourceTaskName(sourceSetName: String): String {
+private fun processResourceTaskName(sourceSetName: String): String {
     val infix = if (sourceSetName == "main") "" else sourceSetName.capitalized()
     return "process${infix}Resources"
+}
+
+private const val SUPPRESS_DEPRECATION = "@file:Suppress(\"DEPRECATION\")"
+
+/**
+ * This file adds [SUPPRESS_DEPRECATION] to the top of a Kotlin file generated
+ * by Protobuf compiler.
+ */
+private fun suppressDeprecationsInKotlin(generatedDir: String, ssn: String) {
+    val kotlinDir = File("${generatedDir}/${ssn}/kotlin")
+
+    kotlinDir.walk().iterator().forEachRemaining {
+        val file = it
+        if (!file.name.endsWith(".kt")) {
+            return@forEachRemaining
+        }
+        val lines = file.readLines()
+        if (lines.isEmpty()) {
+            return@forEachRemaining
+        }
+        if (lines[0] == SUPPRESS_DEPRECATION) {
+            return@forEachRemaining
+        }
+        val withSuppression = mutableListOf<String>()
+        withSuppression.add("// Added by `ProtoTaskExtensions.kt`")
+        withSuppression.add(SUPPRESS_DEPRECATION + lineSeparator())
+        withSuppression.addAll(lines)
+        val text = withSuppression.joinToString(lineSeparator())
+        file.writeText(text)
+    }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.109`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.110`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -64,6 +64,7 @@
      * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.32.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -251,6 +252,7 @@
      * **Project URL:** [https://github.com/java-diff-utils/java-diff-utils](https://github.com/java-diff-utils/java-diff-utils)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.32.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -470,12 +472,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 06 14:09:04 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.109`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.110`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -558,6 +560,7 @@ This report was generated on **Thu Oct 06 14:09:04 EET 2022** using [Gradle-Lice
      * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.32.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -778,6 +781,7 @@ This report was generated on **Thu Oct 06 14:09:04 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/java-diff-utils/java-diff-utils](https://github.com/java-diff-utils/java-diff-utils)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.32.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -997,12 +1001,12 @@ This report was generated on **Thu Oct 06 14:09:04 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 06 14:09:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.109`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.110`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1054,6 +1058,7 @@ This report was generated on **Thu Oct 06 14:09:05 EET 2022** using [Gradle-Lice
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.32.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -1225,6 +1230,7 @@ This report was generated on **Thu Oct 06 14:09:05 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/java-diff-utils/java-diff-utils](https://github.com/java-diff-utils/java-diff-utils)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.32.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -1440,4 +1446,4 @@ This report was generated on **Thu Oct 06 14:09:05 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 06 14:09:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -45,16 +45,16 @@
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.7.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
@@ -188,20 +188,20 @@
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.7.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
@@ -472,7 +472,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 13 00:39:48 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -529,16 +529,16 @@ This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.7.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -717,20 +717,20 @@ This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.7.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
@@ -1001,7 +1001,7 @@ This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 13 00:39:48 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1043,16 +1043,16 @@ This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.7.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
@@ -1170,20 +1170,20 @@ This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.7.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.21.7.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
@@ -1446,4 +1446,4 @@ This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 12 15:30:09 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 13 00:39:49 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-base/build.gradle.kts
+++ b/plugin-base/build.gradle.kts
@@ -28,6 +28,7 @@ import com.google.protobuf.gradle.generateProtoTasks
 import com.google.protobuf.gradle.protobuf
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.gradle.WriteVersions
+import io.spine.internal.gradle.protobuf.setup
 
 dependencies {
     api(gradleApi())
@@ -41,12 +42,12 @@ kotlin {
     explicitApi()
 }
 
+val generatedDir by extra("$projectDir/generated")
+
 protobuf {
     generateProtoTasks {
         for (task in all()) {
-            task.generateDescriptorSet = true
-            task.descriptorSetOptions.path =
-                "$buildDir/descriptors/${task.sourceSet.name}/known_types.desc"
+            task.setup(generatedDir)
         }
     }
 }

--- a/plugin-base/src/main/java/io/spine/tools/gradle/ProtocPluginName.java
+++ b/plugin-base/src/main/java/io/spine/tools/gradle/ProtocPluginName.java
@@ -42,6 +42,16 @@ public enum ProtocPluginName {
     java,
 
     /**
+     * The standard Kotlin protoc plugin.
+     *
+     * <p>Built into the Protobuf compiler.
+     *
+     * @see <a href="https://developers.google.com/protocol-buffers/docs/reference/kotlin-generated">
+     *         Kotlin generated code reference</a>
+     */
+    kotlin,
+
+    /**
      * The standard JavaScript protoc plugin.
      *
      * <p>Built into the Protobuf compiler.

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/ProtocPluginNameTest.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/ProtocPluginNameTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.tools.gradle
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+import com.google.common.truth.Truth.assertThat
+
+/**
+ * This test suite guards against accidental refactoring enum names coming
+ * in the [ProtocPluginName] enum in small caps to uppercase (as it's customary for enums).
+ */
+@DisplayName("`ProtocPluginName` should")
+internal class ProtocPluginNameTest {
+
+    @Test
+    fun `have 'kotlin' name`() {
+        assertThat(ProtocPluginName.kotlin.name)
+            .isEqualTo("kotlin")
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.112</version>
+    <version>2.0.0-SNAPSHOT.113</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.112</version>
+    <version>2.0.0-SNAPSHOT.113</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -145,7 +145,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.21.7</version>
+    <version>3.19.6</version>
   </dependency>
   <dependency>
     <groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.109</version>
+<version>2.0.0-SNAPSHOT.110</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -44,19 +44,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.108</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.spine</groupId>
-    <artifactId>spine-validate</artifactId>
-    <version>2.0.0-SNAPSHOT.108</version>
+    <version>2.0.0-SNAPSHOT.112</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.108</version>
+    <version>2.0.0-SNAPSHOT.112</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.validation</groupId>
+    <artifactId>spine-validation-java-runtime</artifactId>
+    <version>2.0.0-SNAPSHOT.32</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/tool-base/build.gradle.kts
+++ b/tool-base/build.gradle.kts
@@ -24,9 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.generateProtoTasks
+import com.google.protobuf.gradle.protobuf
+
 import io.spine.internal.dependency.JavaPoet
 import io.spine.internal.dependency.JavaX
 import io.spine.internal.dependency.Spine
+import io.spine.internal.gradle.protobuf.setup
 
 val baseVersion: String by extra
 
@@ -39,4 +43,13 @@ dependencies {
     implementation(spine.validation.runtime)
 
     testImplementation(spine.testlib)
+}
+
+val generatedDir by extra("$projectDir/generated")
+protobuf {
+    generateProtoTasks {
+        for (task in all()) {
+            task.setup(generatedDir)
+        }
+    }
 }

--- a/tool-base/build.gradle.kts
+++ b/tool-base/build.gradle.kts
@@ -36,8 +36,7 @@ dependencies {
 
     val spine = Spine(project)
     api(spine.base)
-
-    implementation("io.spine:spine-validate:$baseVersion")
+    implementation(spine.validation.runtime)
 
     testImplementation(spine.testlib)
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,5 +24,5 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val baseVersion: String by extra("2.0.0-SNAPSHOT.112")
+val baseVersion: String by extra("2.0.0-SNAPSHOT.113")
 val versionToPublish: String by extra("2.0.0-SNAPSHOT.110")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,5 +24,5 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val baseVersion: String by extra("2.0.0-SNAPSHOT.108")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.109")
+val baseVersion: String by extra("2.0.0-SNAPSHOT.112")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.110")


### PR DESCRIPTION
This PR adds `kotlin` to the enumeration of `protoc` plugin names.

Dependencies were also updated.