### PR TITLE
Generate inline comments

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -472,12 +472,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 13 12:53:05 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 28 15:55:41 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1001,12 +1001,12 @@ This report was generated on **Thu Oct 13 12:53:05 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 13 12:53:06 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 28 15:55:41 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1446,4 +1446,4 @@ This report was generated on **Thu Oct 13 12:53:06 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 13 12:53:06 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Oct 28 15:55:42 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-base/src/main/java/io/spine/tools/gradle/project/DependantProject.java
+++ b/plugin-base/src/main/java/io/spine/tools/gradle/project/DependantProject.java
@@ -40,7 +40,6 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.111</version>
+<version>2.0.0-SNAPSHOT.112</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tool-base/src/main/java/io/spine/tools/code/Indent.java
+++ b/tool-base/src/main/java/io/spine/tools/code/Indent.java
@@ -26,7 +26,6 @@
 
 package io.spine.tools.code;
 
-import com.google.common.base.Strings;
 import com.google.errorprone.annotations.Immutable;
 
 import java.io.Serializable;

--- a/tool-base/src/main/java/io/spine/tools/js/fs/FileName.java
+++ b/tool-base/src/main/java/io/spine/tools/js/fs/FileName.java
@@ -37,7 +37,6 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.repeat;
 import static io.spine.tools.fs.FileReference.currentDirectory;
 import static io.spine.tools.fs.FileReference.parentDirectory;
 import static io.spine.tools.fs.FileReference.splitter;

--- a/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
+++ b/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
@@ -114,6 +114,7 @@ public abstract class Language internal constructor(
  *
  * Supports double-slash comments (`// <comment body>`).
  */
+@Deprecated("Use `SlashAsteriskCommentLang` instead.")
 public class SlashCommentLanguage(
     name: String,
     fileExtensions: Iterable<String>
@@ -123,11 +124,25 @@ public class SlashCommentLanguage(
 }
 
 /**
+ * A C-like language.
+ *
+ * Supports slash-asterisk-asterisk-slash comments (`/* <comment body> */`).
+ */
+public class SlashAsteriskCommentLang(
+    name: String,
+    fileExtensions: Iterable<String>
+) : Language(name, fileExtensions) {
+
+    override fun comment(line: String): String = "/* $line */"
+}
+
+
+/**
  * A collection of commonly used [Language]s.
  *
  * If this prepared set is not enough, users are encouraged to create custom [Language] types
  * by either extending the class directly, or using one of its existing subtypes, such as
- * [SlashCommentLanguage].
+ * [SlashAsteriskCommentLang].
  */
 public object CommonLanguages {
 
@@ -151,13 +166,13 @@ public object CommonLanguages {
 
     @get:JvmName("kotlin")
     @JvmStatic
-    public val Kotlin: Language = SlashCommentLanguage("Kotlin", listOf("kt"))
+    public val Kotlin: Language = SlashAsteriskCommentLang("Kotlin", listOf("kt"))
 
     @get:JvmName("java")
     @JvmStatic
-    public val Java: Language = SlashCommentLanguage("Java", listOf("java"))
+    public val Java: Language = SlashAsteriskCommentLang("Java", listOf("java"))
 
     @get:JvmName("javaScript")
     @JvmStatic
-    public val JavaScript: Language = SlashCommentLanguage("JavaScript", listOf("js"))
+    public val JavaScript: Language = SlashAsteriskCommentLang("JavaScript", listOf("js"))
 }

--- a/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
+++ b/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
@@ -136,7 +136,6 @@ public class SlashAsteriskCommentLang(
     override fun comment(line: String): String = "/* $line */"
 }
 
-
 /**
  * A collection of commonly used [Language]s.
  *

--- a/tool-base/src/test/kotlin/io/spine/tools/code/LanguageTest.kt
+++ b/tool-base/src/test/kotlin/io/spine/tools/code/LanguageTest.kt
@@ -52,7 +52,7 @@ class `'Language' should` {
 
     @Test
     fun `format a test line as comments`() {
-        assertThat(Java.comment("Hey!")).isEqualTo("// Hey!")
+        assertThat(Java.comment("Hey!")).isEqualTo("/* Hey! */")
     }
 
     @Test
@@ -74,7 +74,7 @@ class `'Language' should` {
     @Nested
     inner class `support more than one file extension` {
 
-        private val cpp = SlashCommentLanguage("C++", listOf(".HPP", ".cc", ".CPP", "h"))
+        private val cpp = SlashAsteriskCommentLang("C++", listOf(".HPP", ".cc", ".CPP", "h"))
 
         @Test
         fun `sorting and lower-casing them on initialization`() {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,4 +25,4 @@
  */
 
 val baseVersion: String by extra("2.0.0-SNAPSHOT.113")
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.111")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.112")


### PR DESCRIPTION
In this PR we change the `Language` from generating single-line comments to generating multiline, or, more relevantly for us, inline comments.
