### PR TITLE
Fix concurrent modification issue in `ProtobufGradlePluginAdapter`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@
 #
 # Therefore, instructions below are superset of instructions required for all the projects.
 
+.DS_Store
+
 # IntelliJ IDEA modules and interim config files.
 *.iml
 .idea/*.xml

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.153`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.154`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -639,12 +639,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 15:38:09 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 12:09:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.153`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.154`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.1.
@@ -1400,12 +1400,12 @@ This report was generated on **Tue Jan 03 15:38:09 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 15:38:09 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 12:09:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.153`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.154`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2089,4 +2089,4 @@ This report was generated on **Tue Jan 03 15:38:09 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 03 15:38:09 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 12:09:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -639,7 +639,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 12:09:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 20:01:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1400,7 +1400,7 @@ This report was generated on **Thu Jan 12 12:09:05 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 12:09:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 20:01:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2089,4 +2089,4 @@ This report was generated on **Thu Jan 12 12:09:06 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 12 12:09:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 12 20:01:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-base/src/main/java/io/spine/tools/gradle/ProtocConfigurationPlugin.java
+++ b/plugin-base/src/main/java/io/spine/tools/gradle/ProtocConfigurationPlugin.java
@@ -26,7 +26,6 @@
 
 package io.spine.tools.gradle;
 
-import com.google.errorprone.annotations.InlineMe;
 import com.google.protobuf.gradle.ExecutableLocator;
 import com.google.protobuf.gradle.GenerateProtoTask;
 import com.google.protobuf.gradle.ProtobufExtension;
@@ -42,7 +41,6 @@ import static io.spine.tools.gradle.protobuf.ProtobufDependencies.gradlePlugin;
 import static io.spine.tools.gradle.protobuf.ProtobufDependencies.protobufCompiler;
 import static io.spine.tools.gradle.protobuf.ProtobufGradlePluginAdapterKt.getProtobufGradlePluginAdapter;
 import static io.spine.tools.gradle.task.Tasks.getDescriptorSetFile;
-import static org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME;
 
 /**
  * An abstract base for Gradle plugins that configure Protobuf compilation.
@@ -53,23 +51,6 @@ import static org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME;
 @SuppressWarnings("AbstractClassNeverImplemented")
 // Implemented in language-specific parts of Model Compiler.
 public abstract class ProtocConfigurationPlugin implements Plugin<Project> {
-
-    /**
-     * Tells if the source set of the given task contains {@code "test"} in its name.
-     *
-     * @deprecated Please a name of the source set of the given task instead.
-     */
-    @SuppressWarnings("WeakerAccess") // This method is used by implementing classes.
-    @Deprecated
-    @InlineMe(
-            replacement = "protocTask.getSourceSet().getName().contains(TEST_SOURCE_SET_NAME)",
-            staticImports = "org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME"
-    )
-    protected static boolean isTestsTask(GenerateProtoTask protocTask) {
-        return protocTask.getSourceSet()
-                         .getName()
-                         .contains(TEST_SOURCE_SET_NAME);
-    }
 
     @Override
     public void apply(Project project) {

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/protobuf/ProtobufGradlePluginAdapter.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/protobuf/ProtobufGradlePluginAdapter.kt
@@ -160,7 +160,6 @@ private class NewApi(override val project: Project): ProtobufGradlePluginAdapter
         val callAction : Action<Any> = Action<Any> { genProtoTasks: Any ->
             configureAllAction(genProtoTasks, action)
         }
-        // Now pass the closure for the Protobuf Gradle plugin for being applied later.
         generateProtoTasks.invoke(extension, callAction)
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.153</version>
+<version>2.0.0-SNAPSHOT.154</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
+++ b/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
@@ -112,20 +112,6 @@ public abstract class Language internal constructor(
 /**
  * A C-like language.
  *
- * Supports double-slash comments (`// <comment body>`).
- */
-@Deprecated("Use `SlashAsteriskCommentLang` instead.")
-public class SlashCommentLanguage(
-    name: String,
-    fileExtensions: Iterable<String>
-) : Language(name, fileExtensions) {
-
-    override fun comment(line: String): String = "// $line"
-}
-
-/**
- * A C-like language.
- *
  * Supports slash-asterisk-asterisk-slash comments (`/* <comment body> */`).
  */
 public class SlashAsteriskCommentLang(

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.153")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.154")


### PR DESCRIPTION
This PR fixes the issue of `ProtobufGradlePluginAdapter` which did not allow to create Gradle tasks in configuration actions passed to `GenerateProtoTask`s. See [similar issue](https://github.com/avast/gradle-docker-compose-plugin/issues/210) for details. 

Our issue was addressed by iterating over a copy of the collection of these tasks exposed by Protobuf Gradle Plugin.

Other notable changes:
 * Additional debug logging was added in the task configuration code.
 * Deprecated `SlashCommentLanguage` class was removed.
 * Deprecated `ProtocConfigurationPlugin.isTestsTask()` method was removed.

