### PR TITLE
Suppress detekt warnings

### DIFF
--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -90,7 +90,6 @@ project.run {
     configureTaskDependencies()
 }
 
-
 typealias Module = Project
 
 fun Module.addDependencies() {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -641,12 +641,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 28 17:36:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 28 18:56:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.1.
@@ -1398,12 +1398,12 @@ This report was generated on **Tue Feb 28 17:36:50 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 28 17:36:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 28 18:56:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2083,4 +2083,4 @@ This report was generated on **Tue Feb 28 17:36:50 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 28 17:36:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 28 18:56:12 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-base/build.gradle.kts
+++ b/plugin-base/build.gradle.kts
@@ -27,10 +27,6 @@
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.gradle.WriteVersions
 
-plugins {
-    `detekt-code-analysis`
-}
-
 dependencies {
     compileOnlyApi(gradleApi())
     compileOnlyApi(Protobuf.GradlePlugin.lib)

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/LoggerExts.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/LoggerExts.kt
@@ -76,6 +76,7 @@ public inline fun Logger.error(message: () -> String) {
  *         the action
  * @return the result of invoking the action.
  */
+@Suppress("ImplicitDefaultLocale", "MagicNumber") // intended in `String.format()` below.
 public inline fun <T> Logger.logTime(action: String, fn: () -> T): T {
     val startNs = System.nanoTime()
     val result = fn()

--- a/plugin-testlib/build.gradle.kts
+++ b/plugin-testlib/build.gradle.kts
@@ -26,10 +26,6 @@
 
 import io.spine.internal.dependency.Spine
 
-plugins {
-    `detekt-code-analysis`
-}
-
 dependencies {
     api(gradleApi())
     api(gradleTestKit())

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.160</version>
+<version>2.0.0-SNAPSHOT.161</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.160")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.161")


### PR DESCRIPTION
This PR suppresses detekt warnings that failed publishing of the previous PR. It still to be understood why locally executed detekt did not spot this issues.

Still, this PR also removes redundant detekt plugin inclusion in favor of one done in the `module` script plugin.
