### PR TITLE
Add `Protobuf` and `TypeScript` languages

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -29,17 +29,107 @@ package io.spine.internal.dependency
 /**
  * Dependencies on ProtoData modules.
  *
+ * In order to use locally published ProtoData version instead of the version from a public plugin
+ * registry, set the `PROTODATA_VERSION` and/or the `PROTODATA_DF_VERSION` environment variables
+ * and stop the Gradle daemons so that Gradle observes the env change:
+ * ```
+ * export PROTODATA_VERSION=0.43.0-local
+ * export PROTODATA_DF_VERSION=0.41.0
+ *
+ * ./gradle --stop
+ * ./gradle build   # Conduct the intended checks.
+ * ```
+ *
+ * Then, in order to reset the console to run the usual versions again, remove the values of
+ * the environment variables and stop the daemon:
+ * ```
+ * export PROTODATA_VERSION=""
+ * export PROTODATA_DF_VERSION=""
+ *
+ * ./gradle --stop
+ * ```
+ *
  * See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
  */
-@Suppress("unused", "ConstPropertyName")
+@Suppress(
+    "unused" /* Some subprojects do not use ProtoData directly. */,
+    "ConstPropertyName" /* We use custom convention for artifact properties. */,
+    "MemberVisibilityCanBePrivate" /* The properties are used directly by other subprojects. */,
+    "KDocUnresolvedReference" /* Referencing private properties in constructor KDoc. */
+)
 object ProtoData {
-    const val version = "0.11.3"
-    const val dogfoodingVersion = "0.9.11"
     const val group = "io.spine.protodata"
-    const val compiler = "$group:protodata-compiler:$version"
-
-    const val codegenJava = "io.spine.protodata:protodata-codegen-java:$version"
-
     const val pluginId = "io.spine.protodata"
-    const val pluginLib = "${Spine.group}:protodata:$version"
+
+    /**
+     * The version of ProtoData dependencies.
+     */
+    val version: String
+    private const val fallbackVersion = "0.11.0"
+
+    /**
+     * The distinct version of ProtoData used by other build tools.
+     *
+     * When ProtoData is used both for building the project and as a part of the Project's
+     * transitional dependencies, this is the version used to build the project itself.
+     */
+    val dogfoodingVersion: String
+    private const val fallbackDfVersion = "0.9.11"
+
+    /**
+     * The artifact for the ProtoData Gradle plugin.
+     */
+    val pluginLib: String
+
+    val api
+        get() = "$group:protodata-api:$version"
+    val compiler
+        get() = "$group:protodata-compiler:$version"
+    val codegenJava
+        get() = "$group:protodata-codegen-java:$version"
+
+    /**
+     * An env variable storing a custom [version].
+     */
+    private const val VERSION_ENV = "PROTODATA_VERSION"
+
+    /**
+     * An env variable storing a custom [dogfoodingVersion].
+     */
+    private const val DF_VERSION_ENV = "PROTODATA_DF_VERSION"
+
+    /**
+     * Sets up the versions and artifacts for the build to use.
+     *
+     * If either [VERSION_ENV] or [DF_VERSION_ENV] is set, those versions are used instead of
+     * the hardcoded ones. Also, in this mode, the [pluginLib] coordinates are changed so that
+     * it points at a locally published artifact. Otherwise, it points at an artifact that would be
+     * published to a public plugin registry.
+     */
+    init {
+        val experimentVersion = System.getenv(VERSION_ENV)
+        val experimentDfVersion = System.getenv(DF_VERSION_ENV)
+        if (experimentVersion?.isNotBlank() == true || experimentDfVersion?.isNotBlank() == true) {
+            version = experimentVersion ?: fallbackVersion
+            dogfoodingVersion = experimentDfVersion ?: fallbackDfVersion
+
+            pluginLib = "${group}:gradle-plugin:$version"
+            println("""
+
+                ❗ Running an experiment with ProtoData. ❗
+                -----------------------------------------
+                    Regular version     = v$version
+                    Dogfooding version  = v$dogfoodingVersion
+                
+                    ProtoData Gradle plugin can now be loaded from Maven Local.
+                    
+                    To reset the versions, erase the `$$VERSION_ENV` and `$$DF_VERSION_ENV` environment variables. 
+
+            """.trimIndent())
+        } else {
+            version = fallbackVersion
+            dogfoodingVersion = fallbackDfVersion
+            pluginLib = "${Spine.group}:protodata:$version"
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -59,7 +59,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.209"
+        const val logging = "2.0.0-SNAPSHOT.225"
 
         /**
          * The version of [Spine.testlib].
@@ -75,7 +75,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.157"
+        const val core = "2.0.0-SNAPSHOT.159"
 
         /**
          * The version of [Spine.modelCompiler].
@@ -89,7 +89,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.168"
+        const val mcJava = "2.0.0-SNAPSHOT.170"
 
         /**
          * The version of [Spine.baseTypes].
@@ -103,7 +103,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
          */
-        const val time = "2.0.0-SNAPSHOT.133"
+        const val time = "2.0.0-SNAPSHOT.134"
 
         /**
          * The version of [Spine.change].
@@ -165,8 +165,20 @@ object Spine {
         const val version = ArtifactVersion.logging
         const val lib = "$group:spine-logging:$version"
         const val backend = "$group:spine-logging-backend:$version"
+        const val log4j2Backend = "$group:spine-logging-log4j2-backend:$version"
         const val context = "$group:spine-logging-context:$version"
+        const val grpcContext = "$group:spine-logging-grpc-context:$version"
+
+        @Deprecated(
+            message = "Please use `Logging.lib` instead.",
+            replaceWith = ReplaceWith("lib")
+        )
         const val floggerApi = "$group:spine-flogger-api:$version"
+
+        @Deprecated(
+            message = "Please use `grpcContext` instead.",
+            replaceWith = ReplaceWith("grpcContext")
+        )
         const val floggerGrpcContext = "$group:spine-flogger-grpc-context:$version"
         const val smokeTest = "$group:spine-logging-smoke-test:$version"
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object Validation {
-    const val version = "2.0.0-SNAPSHOT.103"
+    const val version = "2.0.0-SNAPSHOT.104"
     const val group = "io.spine.validation"
     const val runtime = "$group:spine-validation-java-runtime:$version"
     const val java = "$group:spine-validation-java:$version"

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -650,12 +650,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Sep 03 23:19:51 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 04 14:23:46 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1419,12 +1419,12 @@ This report was generated on **Sun Sep 03 23:19:51 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Sep 03 23:19:52 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 04 14:23:46 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.184`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.185`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2113,4 +2113,4 @@ This report was generated on **Sun Sep 03 23:19:52 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Sep 03 23:19:52 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 04 14:23:46 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.184</version>
+<version>2.0.0-SNAPSHOT.185</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -44,7 +44,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.209</version>
+    <version>2.0.0-SNAPSHOT.225</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -56,7 +56,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.validation</groupId>
     <artifactId>spine-validation-java-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.103</version>
+    <version>2.0.0-SNAPSHOT.104</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
+++ b/tool-base/src/main/kotlin/io/spine/tools/code/Language.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,11 @@ import java.nio.file.Path
  * This abstract class is supposed to be extended by an `object` to make it a singleton
  * and a typed [Language] instance.
  *
+ * @see Protobuf
  * @see Java
  * @see Kotlin
  * @see JavaScript
- * @see AnyLanguage
+ * @see TypeScript
  */
 public abstract class Language
 protected constructor(
@@ -132,59 +133,6 @@ public abstract class SlashAsteriskCommentLang(
 }
 
 /**
- * A collection of commonly used [Language]s.
- *
- * If this prepared set is not enough, users are encouraged to create custom [Language] types
- * by either extending the class directly, or using one of its existing subtypes, such as
- * [SlashAsteriskCommentLang].
- */
-@Deprecated("Please use typed `Language` objects instead.")
-public object CommonLanguages {
-
-    /**
-     * Any language will do.
-     *
-     * This instance indicates that any programming language can be accepted.
-     *
-     * Intended to be used for filtering source files by language via file name conventions.
-     * If no filtering required, but a [Language] is needed, use `CommonLanguages.any`.
-     *
-     * Does not support [comments][Language.comment].
-     */
-    @get:JvmName("any")
-    @JvmStatic
-    @Deprecated(
-        "Use `io.spine.tools.code.AnyLanguage` instead.",
-        ReplaceWith("io.spine.tools.code.AnyLanguage")
-    )
-    public val any: Language = AnyLanguage
-
-    @get:JvmName("kotlin")
-    @JvmStatic
-    @Deprecated(
-        "Use `io.spine.tools.code.Kotlin` instead.",
-        ReplaceWith("io.spine.tools.code.Kotlin")
-    )
-    public val Kotlin: Language = io.spine.tools.code.Kotlin
-
-    @get:JvmName("java")
-    @JvmStatic
-    @Deprecated(
-        "Use `io.spine.tools.code.Java` instead.",
-        ReplaceWith("io.spine.tools.code.Java")
-    )
-    public val Java: Language = io.spine.tools.code.Java
-
-    @get:JvmName("javaScript")
-    @JvmStatic
-    @Deprecated(
-        "Use `io.spine.tools.code.JavaScript` instead.",
-        ReplaceWith("io.spine.tools.code.JavaScript")
-    )
-    public val JavaScript: Language = io.spine.tools.code.JavaScript
-}
-
-/**
  * This object indicates that any programming language can be accepted.
  *
  * Intended to be used for filtering source files by language via file name conventions.
@@ -192,7 +140,7 @@ public object CommonLanguages {
  *
  * Does not support [comments][Language.comment].
  */
-public object AnyLanguage: Language("any language", listOf(""), Glob.any) {
+public object AnyLanguage : Language("any language", listOf(""), Glob.any) {
     override fun comment(line: String): String {
         throw UnsupportedOperationException("`$name` does not support comments.")
     }
@@ -205,10 +153,22 @@ public object AnyLanguage: Language("any language", listOf(""), Glob.any) {
 }
 
 /**
+ * A typed [Language] for Protocol Buffers.
+ */
+public object Protobuf : SlashAsteriskCommentLang("Protobuf", listOf("proto")) {
+
+    /**
+     * Returns the typed instance of this language for usage in Java code.
+     */
+    @JvmStatic
+    public fun lang(): Protobuf = this
+}
+
+/**
  * A typed [Language] for Java.
  */
 @Suppress("ACCIDENTAL_OVERRIDE")
-public object Java: SlashAsteriskCommentLang("Java", listOf("java")) {
+public object Java : SlashAsteriskCommentLang("Java", listOf("java")) {
 
     /**
      * Returns the typed instance of this language for usage in Java code.
@@ -232,11 +192,27 @@ public object Kotlin: SlashAsteriskCommentLang("Kotlin", listOf("kt")) {
 /**
  * A typed [Language] for JavaScript.
  */
-public object JavaScript: SlashAsteriskCommentLang("JavaScript", listOf("js")) {
+public object JavaScript : SlashAsteriskCommentLang("JavaScript", listOf("js")) {
 
     /**
      * Returns the typed instance of this language for usage in Java code.
      */
     @JvmStatic
     public fun lang(): JavaScript = this
+}
+
+/**
+ * A typed [Language] for TypeScript.
+ *
+ * @see <a href="https://stackoverflow.com/questions/37063569/typescript-various-file-extensions-explained">
+ *     TypeScript file extensions explained</a>
+ */
+public object TypeScript :
+    SlashAsteriskCommentLang("TypeScript", listOf("ts", "d.ts", "js", "map")) {
+
+    /**
+    * Returns the typed instance of this language for usage in Java code.
+    */
+    @JvmStatic
+    public fun lang(): TypeScript = this
 }

--- a/tool-base/src/test/kotlin/io/spine/tools/code/LanguageKotlinApiSpec.kt
+++ b/tool-base/src/test/kotlin/io/spine/tools/code/LanguageKotlinApiSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,10 +64,10 @@ class LanguageKotlinApiSpec {
     @Test
     fun `filter files by their extension`() {
         // Passing the directory, rather than file.
-        JavaScript.matches(File("Windows")) shouldBe false
+        Protobuf.matches(File("Windows")) shouldBe false
 
         // Passing file with extension.
-        JavaScript.matches(File("safari.swift")) shouldBe false
+        TypeScript.matches(File("safari.swift")) shouldBe false
 
         JavaScript.matches(File("mozilla.js")) shouldBe true
     }
@@ -99,6 +99,17 @@ class LanguageKotlinApiSpec {
         private fun assertMatches(file: String) {
             val path = Paths.get(file)
             cpp.matches(path) shouldBe true
+        }
+    }
+
+    @Test
+    fun `'TypeScript' should recognise all the files`() {
+        with(TypeScript) {
+            matches(File("foo.ts")) shouldBe true
+            matches(File("jQuery.d.ts")) shouldBe true
+            matches(File("jQuery.js")) shouldBe true
+            matches(File("bar.map")) shouldBe true
+            matches(File("Main.java")) shouldBe false
         }
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.184")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.185")


### PR DESCRIPTION
This PR adds `Protobuf` and `TypeScript` types of `Language`.

Other changes:
  * Latest `config` was applied.
  * Deprecated `CommonLanguages` was removed.
