### PR TITLE
Use `buildSrc.jar` when copying `buildSrc` folder during IG testing

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.195`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.196`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -636,12 +636,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 05 17:56:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 10 18:52:01 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.195`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.196`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1391,12 +1391,12 @@ This report was generated on **Mon Feb 05 17:56:07 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 05 17:56:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 10 18:52:01 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.195`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.196`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2023,12 +2023,12 @@ This report was generated on **Mon Feb 05 17:56:07 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 05 17:56:07 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 10 18:52:01 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.195`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.196`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2759,12 +2759,12 @@ This report was generated on **Mon Feb 05 17:56:07 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 05 17:56:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 10 18:52:02 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.195`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.196`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3443,4 +3443,4 @@ This report was generated on **Mon Feb 05 17:56:08 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 05 17:56:08 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 10 18:52:02 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/BuildSrcCopy.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/BuildSrcCopy.kt
@@ -74,7 +74,7 @@ internal data class BuildSrcCopy(
      * Such references are resoled if classes under `buildSrc/build/classes` are available
      * for the Gradle runner.
      *
-     * So far, any "field" tests have shown that this directory
+     * So far, all "field" tests have shown that this directory
      * **cannot** be re-used, as its contents will be regenerated anyway,
      * because Kotlin compiler detects the paths of source files
      * in the "copied" version of `buildSrc/src` to be different

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/BuildSrcCopy.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/BuildSrcCopy.kt
@@ -107,7 +107,7 @@ internal data class BuildSrcCopy(
         if (!includeBuildDir) {
             add("build")
         }
-        if(!includeSourceDir) {
+        if (!includeSourceDir) {
             add("src")
         }
     }
@@ -121,18 +121,21 @@ internal data class BuildSrcCopy(
     }
 
     private fun copyJar(rootPath: Path, targetDir: Path) {
-        val jar = rootPath / "build" / "libs" / JAR_NAME
+        val jar = rootPath / FOLDER_NAME / "build" / "libs" / JAR_NAME
         if (includeBuildSrcJar && jar.exists()) {
-            val jarTarget = targetDir / FOLDER_NAME / jar.fileName
+            val jarTarget = targetDir / FOLDER_NAME / JAR_NAME
             Files.copy(jar, jarTarget)
         }
     }
 
-    /** Tests if the given path should be copied. */
+    /**
+     * Tests if the given path should be copied.
+     *
+     * This method does not account for `buildSrc.jar`,
+     * as the folder structure for its target location (`<targetDir>/buildSrc`)
+     * from the original folder structure (`<rootDir>/buildSrc/build/libs/buildSrc.jar`).
+     **/
     override fun test(path: Path): Boolean {
-        if(path.name == JAR_NAME) {
-            return includeBuildSrcJar
-        }
         return path.any { doNotCopy.contains(it.name) }.not()
     }
 }

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gradle/testing/BuildSrcCopySpec.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gradle/testing/BuildSrcCopySpec.kt
@@ -93,9 +93,6 @@ class BuildSrcCopySpec {
     fun `copy 'buildSrc(dot)jar' file by default`() {
         val tool = BuildSrcCopy()
         tool.includeBuildSrcJar shouldBe true
-
-        val jarPath = Paths.get("build/lib/${JAR_NAME}")
-        tool.test(jarPath) shouldBe true
     }
 
     @Test

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gradle/testing/BuildSrcCopySpec.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gradle/testing/BuildSrcCopySpec.kt
@@ -27,16 +27,26 @@
 package io.spine.tools.gradle.testing
 
 import io.kotest.matchers.shouldBe
+import io.spine.tools.gradle.testing.BuildSrcCopy.Companion.FOLDER_NAME
+import io.spine.tools.gradle.testing.BuildSrcCopy.Companion.JAR_NAME
+import java.io.File
+import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.div
+import kotlin.io.path.exists
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
 @DisplayName("`BuildSrcCopy` should")
 class BuildSrcCopySpec {
 
     private lateinit var buildSrcCopy: BuildSrcCopy
+
+    @field:TempDir
+    private lateinit var tempDir: File
 
     @Test
     fun `copy directories with source code`() {
@@ -80,8 +90,40 @@ class BuildSrcCopySpec {
     }
 
     @Test
+    fun `copy 'buildSrc(dot)jar' file by default`() {
+        val tool = BuildSrcCopy()
+        tool.includeBuildSrcJar shouldBe true
+
+        val jarPath = Paths.get("build/lib/${JAR_NAME}")
+        tool.test(jarPath) shouldBe true
+    }
+
+    @Test
     fun `not copy 'build' dir by default`() {
         BuildSrcCopy().includeBuildDir shouldBe false
+    }
+
+    @Test
+    fun `not copy 'src' dir by default`() {
+        BuildSrcCopy().includeSourceDir shouldBe false
+    }
+
+    @Test
+    fun `copy only first-level files of 'buildSrc' files and 'buildSrc(dot)jar' by default`() {
+        val target = tempDir.toPath()
+        BuildSrcCopy().writeTo(target)
+
+        assertCopied(target, JAR_NAME)
+
+        // We expect at least this file to be present in root `buildSrc` folder.
+        assertCopied(target, "build.gradle.kts")
+    }
+
+    private fun assertCopied(target: Path, filename: String) {
+        val maybeCopy = target / FOLDER_NAME / filename
+        assertTrue(maybeCopy.exists()) {
+            "`$filename` is expected to be copied by default."
+        }
     }
 
     private fun assertIsSourceCode(path: String) {

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gradle/testing/BuildSrcCopySpec.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gradle/testing/BuildSrcCopySpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ class BuildSrcCopySpec {
 
     @Test
     fun `copy directories with source code`() {
-        buildSrcCopy = BuildSrcCopy(false)
+        buildSrcCopy = BuildSrcCopy(includeBuildSrcJar = false, includeSourceDir = true)
         listOf(
             "aus.weis",
             "src/main/kotlin",
@@ -61,7 +61,11 @@ class BuildSrcCopySpec {
 
     @Test
     fun `include 'build' directory if instructed`() {
-        buildSrcCopy = BuildSrcCopy(true)
+        buildSrcCopy = BuildSrcCopy(
+            includeBuildSrcJar = false,
+            includeSourceDir = true,
+            includeBuildDir = true
+        )
 
         listOf(
             "build",
@@ -76,8 +80,8 @@ class BuildSrcCopySpec {
     }
 
     @Test
-    fun `copy 'build' dir by default`() {
-        BuildSrcCopy().includeBuildDir shouldBe true
+    fun `not copy 'build' dir by default`() {
+        BuildSrcCopy().includeBuildDir shouldBe false
     }
 
     private fun assertIsSourceCode(path: String) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.195</version>
+<version>2.0.0-SNAPSHOT.196</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tool-base/src/main/java/io/spine/tools/java/code/column/ColumnAccessor.java
+++ b/tool-base/src/main/java/io/spine/tools/java/code/column/ColumnAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ final class ColumnAccessor implements GeneratedMethodSpec {
     }
 
     /**
-     * Returns the name of the Java type of a column.
+     * Returns the name of the Java type of column.
      */
     private ParameterizedTypeName columnType() {
         var result = JavaPoetName.of(EntityColumn.class);

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.195")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.196")


### PR DESCRIPTION
This PR changes the behaviour of `BuildSrcCopy`, so that integration tests using this tool could speed up their build time by using `buildSrc.jar` (an artifact assembled by Gradle) instead of re-compiling the `buildSrc` source files again.

For that, a dependency onto this JAR should be added to the `buildSrc`-build script of the respective integration-testing project. In future PR to `config`, some changes will be done to this file as well.

The API of `BuildSrcCopy` has been changed in several aspects: 

* By default:
     *  `<original project root>/buildSrc/build/libs/buildSrc.jar` is copied to the **root** (!) of the target folder set for `BuildSrcCopy`. It is expected that the original `buildSrc.jar` will always be in place at the moment copying (which is usually during some integration test). 
     * First-level files residing in  `<original project root>/buildSrc` are also copied; in Spine they are `build.gradle.kts` and `aus.weis`.
     * No other files or folders are copied.
 * `BuildSrcCopy` ctor allows to change the default behaviour by including `src` contents, and/or `buildSrc/build` folder  into copy operation. It is also possible to exclude just `buildSrc.jar` alone.