### PR TITLE
Improve `GradleProject` API for build speed

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.196`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.197`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -636,12 +636,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 10 18:52:01 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 11 18:04:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.196`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.197`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1391,12 +1391,12 @@ This report was generated on **Sat Feb 10 18:52:01 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 10 18:52:01 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 11 18:04:36 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.196`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.197`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2023,12 +2023,12 @@ This report was generated on **Sat Feb 10 18:52:01 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 10 18:52:01 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 11 18:04:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.196`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.197`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2759,12 +2759,12 @@ This report was generated on **Sat Feb 10 18:52:01 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 10 18:52:02 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 11 18:04:37 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.196`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.197`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3443,4 +3443,4 @@ This report was generated on **Sat Feb 10 18:52:02 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 10 18:52:02 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 11 18:04:38 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProject.kt
@@ -27,6 +27,7 @@ package io.spine.tools.gradle.testing
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue
 import io.spine.tools.gradle.task.TaskName
+import io.spine.tools.gradle.testing.GradleProject.Companion.setupAt
 import java.io.File
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
@@ -64,9 +65,17 @@ public class GradleProject internal constructor(setup: GradleProjectSetup) {
     /**
      * The runner for executing tasks.
      */
-    public val runner: GradleRunner = GradleRunner.create()
-        .withProjectDir(setup.projectDir)
-        .withDebug(setup.debug)
+    public val runner: GradleRunner by lazy {
+        val runner = GradleRunner.create()
+            .withProjectDir(setup.projectDir)
+            .withDebug(setup.debug)
+        if (setup.useSharedTestKit) {
+            val sharedDir = RootProject.testKitTempDir().toFile()
+            sharedDir.mkdirs()
+            runner.withTestKitDir(sharedDir)
+        }
+        runner
+    }
 
     init {
         if (setup.addPluginUnderTestClasspath) {

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
@@ -93,6 +93,10 @@ public class GradleProjectSetup internal constructor(
     internal var debug = false
         private set
 
+    /** Whether a [shared Gradle TestKit folder][RootProject.testKitTempDir] should be used. */
+    internal var useSharedTestKit = false
+        private set
+
     /**
      * Determines whether the plugin under test classpath is defined and should be added to
      * the Gradle execution classpath.
@@ -320,6 +324,11 @@ public class GradleProjectSetup internal constructor(
         val r = Replacement(token, replacement)
         this.replacements.add(r)
         return this
+    }
+
+    public fun withSharedTestKitDirectory() : GradleProjectSetup {
+        this.useSharedTestKit = true;
+        return this;
     }
 
     /**

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
@@ -224,10 +224,24 @@ public class GradleProjectSetup internal constructor(
     /**
      * Instructs to copy the `buildSrc` directory from the parent project
      * into the directory of the project to be created.
+     *
+     * If [caching is enabled][cachingEnabled], [BuildSrcCopy] is used by default,
+     * meaning only several files are copied:
+     *  * all first-level files from original `buildSrc` directory as-is;
+     *  * original `/buildSrc/build/libs/buildSrc.jar` is copied to the root
+     *  of the destination `buildSrc` directory — allowing to use it in caching purposes.
+     *
+     *  If caching is disabled, we copy just `buildSrc` sources instead,
+     *  excluding all its "working" subdirectories, such as `.gradle`, `build` etc.,
+     *  as they cannot be reused for caching anyway.
      */
     @JvmOverloads
-    public fun copyBuildSrc(withBuildDir: Boolean = true): GradleProjectSetup {
-        buildSrcCopy = BuildSrcCopy(withBuildDir)
+    public fun copyBuildSrc(cachingEnabled: Boolean = true): GradleProjectSetup {
+        buildSrcCopy = if(cachingEnabled) {
+            BuildSrcCopy()
+        } else {
+            BuildSrcCopy(includeBuildSrcJar = false, includeSourceDir = true)
+        }
         return this
     }
 

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
@@ -241,7 +241,7 @@ public class GradleProjectSetup internal constructor(
      */
     @JvmOverloads
     public fun copyBuildSrc(cachingEnabled: Boolean = true): GradleProjectSetup {
-        buildSrcCopy = if(cachingEnabled) {
+        buildSrcCopy = if (cachingEnabled) {
             BuildSrcCopy()
         } else {
             BuildSrcCopy(includeBuildSrcJar = false, includeSourceDir = true)

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/GradleProjectSetup.kt
@@ -326,6 +326,13 @@ public class GradleProjectSetup internal constructor(
         return this
     }
 
+    /**
+     * Tells the TestKit runner to use a [single shared folder][RootProject.testKitTempDir]
+     * for all tests.
+     *
+     * The idea is that this folder is not deleted on `gradlew clean` phase,
+     * and therefore may be somewhat re-used to speed up the test execution.
+     */
     public fun withSharedTestKitDirectory() : GradleProjectSetup {
         this.useSharedTestKit = true;
         return this;

--- a/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/RootProject.kt
+++ b/plugin-testlib/src/main/kotlin/io/spine/tools/gradle/testing/RootProject.kt
@@ -80,4 +80,16 @@ internal object RootProject {
     fun dir(): File {
         return path().toFile()
     }
+
+    /**
+     * Returns a path to a conventionally established temp directory named `.gradle-test-kit`,
+     * for Gradle TestKit runners.
+     *
+     * It may be used to configure TestKit runners, so that just a single folder
+     * is created for all integration tests.
+     */
+    @JvmStatic
+    fun testKitTempDir() : Path {
+        return path().resolve(".gradle-test-kit")
+    }
 }

--- a/plugin-testlib/src/test/kotlin/io/spine/tools/gradle/testing/SourcesSpec.kt
+++ b/plugin-testlib/src/test/kotlin/io/spine/tools/gradle/testing/SourcesSpec.kt
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.io.TempDir
 class SourcesSpec {
 
     companion object {
-        private const val buildScr = "buildSrc"
+        private const val buildSrc = "buildSrc"
 
         /** The name of the directory under `resources`. */
         private const val resourceDir = "sources_test"
@@ -75,13 +75,13 @@ class SourcesSpec {
         fun `when instructed`() {
             setup.copyBuildSrc()
             setup.create()
-            assertExists(buildScr)
+            assertExists(buildSrc)
         }
 
         @Test
         fun `only when told`() {
             setup.create()
-            assertNotExists(buildScr)
+            assertNotExists(buildSrc)
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.196</version>
+<version>2.0.0-SNAPSHOT.197</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.196")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.197")


### PR DESCRIPTION
This changeset improves the `GradleProject` API used for testing.

In particular:

* `copyBuildSrc(...)` is now equipped with `cachingEnabled: Boolean = true` argument, which tells whether `buildSrc` sources should be used as-is, or a `buildSrc.jar` should be used instead;
* `GradleProjectSetup.withSharedTestKitDirectory()` points the TestKit runners to a single folder, `<root dir>/.gradle-test-kit` by convention; the idea is that this folder is not deleted on `gradlew clean` phase, and therefore may be somewhat re-used to speed up the test execution.