### PR TITLE
Expose `IntelliJ.Java.impl` at `api` level

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.200`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.201`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -636,12 +636,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 28 16:59:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 05 16:40:43 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.200`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.201`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1391,12 +1391,12 @@ This report was generated on **Wed Feb 28 16:59:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 28 16:59:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 05 16:40:44 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.200`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.201`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2237,12 +2237,12 @@ This report was generated on **Wed Feb 28 16:59:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 28 16:59:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 05 16:40:44 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.200`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.201`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3817,12 +3817,12 @@ This report was generated on **Wed Feb 28 16:59:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 28 16:59:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 05 16:40:45 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.200`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.201`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4501,4 +4501,4 @@ This report was generated on **Wed Feb 28 16:59:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 28 16:59:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 05 16:40:45 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.200</version>
+<version>2.0.0-SNAPSHOT.201</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/psi-java/build.gradle.kts
+++ b/psi-java/build.gradle.kts
@@ -59,20 +59,9 @@ dependencies {
     // To use `NonProjectFileWritingAccessProvider`, uncomment the following:
     api(IntelliJ.Platform.ideCoreImpl) { excludeMany() }
 
-    //
-    // Implementation dependencies on IntelliJ artifacts
-    //---------------------------------------------------
-
-    // To access `com.intellij.psi.JspPsiUtil` as a transitive dependency
-    // used by `com.intellij.psi.impl.source.codeStyle.ImportHelper`.
-    implementation(IntelliJ.Jsp.jsp) { excludeMany() }
-
-    implementation(IntelliJ.Xml.xmlPsiImpl) { excludeMany() }
-
-    implementation(IntelliJ.Platform.analysisImpl) { excludeMany() }
-    implementation(IntelliJ.Platform.indexingImpl) { excludeMany() }
-
-    implementation(IntelliJ.Java.impl) {
+    // To expose `JavaCodeStyleSettings` and other types from `com.intellij.psi.codeStyle`
+    // which tools would use for the code style purposes.
+    api(IntelliJ.Java.impl) {
         excludeMany(listOf(
             "ai.grazie.nlp",
             "ai.grazie.spell",
@@ -100,6 +89,21 @@ dependencies {
             "oro",
         ))
     }
+
+    //
+    // Implementation dependencies on IntelliJ artifacts
+    //---------------------------------------------------
+
+    // To access `com.intellij.psi.JspPsiUtil` as a transitive dependency
+    // used by `com.intellij.psi.impl.source.codeStyle.ImportHelper`.
+    implementation(IntelliJ.Jsp.jsp) { excludeMany() }
+
+    implementation(IntelliJ.Xml.xmlPsiImpl) { excludeMany() }
+
+    implementation(IntelliJ.Platform.analysisImpl) { excludeMany() }
+    implementation(IntelliJ.Platform.indexingImpl) { excludeMany() }
+
+
 
     testImplementation(Spine.base)
     testImplementation(Spine.testlib)

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.200")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.201")


### PR DESCRIPTION
This PR promotes the dependency on `com.jetbrains.intellij.java:java-impl` from `implementation` to `api` so that tools can use `JavaCodeStyleSettings` and other Java-related types from the `com.intellij.psi.codeStyle` package.
