### PR TITLE
Fix duplicated artifact prefix

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
@@ -82,10 +82,17 @@ internal sealed class PublicationHandler(
     /**
      * Takes a group name and a version from the given [project] and assigns
      * them to this publication.
+     *
+     * Also, adds the [artifactPrefix][SpinePublishing.artifactPrefix] to
+     * the [artifactId][MavenPublication.setArtifactId] of
+     * this publication, if the prefix is not added yet.
      */
     protected fun MavenPublication.assignMavenCoordinates() {
         groupId = project.group.toString()
-        artifactId = project.spinePublishing.artifactPrefix + artifactId
+        val prefix = project.spinePublishing.artifactPrefix
+        if (!artifactId.startsWith(prefix)) {
+            artifactId = prefix + artifactId
+        }
         version = project.version.toString()
     }
 }
@@ -198,7 +205,7 @@ internal class StandardJavaPublicationHandler(
  *
  * If a module with [publications] declared locally is not specified as one with custom publishing,
  * it may cause a name clash between an artifact produced by the [standard][MavenPublication]
- * publication, and custom ones. In order to have both standard and custom publications,
+ * publication, and custom ones. To have both standard and custom publications,
  * please specify custom artifact IDs or classifiers for each custom publication.
  */
 internal class CustomPublicationHandler(project: Project, destinations: Set<Repository>) :

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -142,7 +142,7 @@ open class SpinePublishing(private val project: Project) {
     /**
      * Set of modules to be published.
      *
-     * Both module's name or path can be used.
+     * Both the module's name or path can be used.
      *
      * Use this property if the extension is configured from a root project's build file.
      *
@@ -180,7 +180,7 @@ open class SpinePublishing(private val project: Project) {
     /**
      * A prefix to be added before the name of each artifact.
      *
-     * Default value is "spine-".
+     * The default value is "spine-".
      */
     var artifactPrefix: String = "spine-"
 
@@ -188,7 +188,7 @@ open class SpinePublishing(private val project: Project) {
      * Allows disabling publishing of [protoJar] artifact, containing all Proto sources
      * from `sourceSets.main.proto`.
      *
-     * Here's an example of how to disable it for some of published modules:
+     * Here's an example of how to disable it for some of the published modules:
      *
      * ```
      * spinePublishing {
@@ -214,8 +214,8 @@ open class SpinePublishing(private val project: Project) {
      * }
      * ```
      *
-     * The resulting artifact is available under "proto" classifier. I.e., in Gradle 7+, one could
-     * depend on it like this:
+     * The resulting artifact is available under "proto" classifier.
+     * For example, in Gradle 7+, one could depend on it like this:
      *
      * ```
      * implementation("io.spine:spine-client:$version@proto")
@@ -227,7 +227,7 @@ open class SpinePublishing(private val project: Project) {
      * Allows enabling publishing of [testJar] artifact, containing compilation output
      * of "test" source set.
      *
-     * Here's an example of how to enable it for some of published modules:
+     * Here's an example of how to enable it for some of the published modules:
      *
      * ```
      * spinePublishing {

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -636,12 +636,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 14:53:49 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 15:50:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1391,12 +1391,12 @@ This report was generated on **Sun Mar 10 14:53:49 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 14:53:50 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 15:50:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2237,12 +2237,12 @@ This report was generated on **Sun Mar 10 14:53:50 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 14:53:50 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 15:50:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3817,12 +3817,12 @@ This report was generated on **Sun Mar 10 14:53:50 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 14:53:50 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 15:50:18 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5341,12 +5341,12 @@ This report was generated on **Sun Mar 10 14:53:50 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 14:53:51 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 15:50:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5929,12 +5929,12 @@ This report was generated on **Sun Mar 10 14:53:51 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 14:53:51 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 15:50:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6613,4 +6613,4 @@ This report was generated on **Sun Mar 10 14:53:51 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 14:53:51 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 15:50:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.204</version>
+<version>2.0.0-SNAPSHOT.205</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/psi-java-bundle-jar/build.gradle.kts
+++ b/psi-java-bundle-jar/build.gradle.kts
@@ -31,15 +31,15 @@ plugins {
     id("com.github.johnrengelman.shadow")
 }
 
+dependencies {
+    api(project(":psi-java"))
+}
+
 /** The publishing settings from the root project. */
 val spinePublishing = rootProject.the<SpinePublishing>()
 
 /** The ID of the far JAR artifact. */
 val projectArtifact = spinePublishing.artifactPrefix + "psi-java-bundle"
-
-dependencies {
-    api(project(":psi-java"))
-}
 
 publishing {
     val groupName = project.group.toString()

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.204")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.205")


### PR DESCRIPTION
This PR fixes the duplicated `spine-` prefix assigned to the `psi-java-bundle` artifact.

Changes made to the `buildSrc` code would be propagated to `config` sometime next week.