### PR TITLE
Use project description in `MavenPublication`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
@@ -80,20 +80,25 @@ internal sealed class PublicationHandler(
     }
 
     /**
-     * Takes a group name and a version from the given [project] and assigns
-     * them to this publication.
+     * Copies the attributes of Gradle [Project] to this [MavenPublication].
      *
-     * Also, adds the [artifactPrefix][SpinePublishing.artifactPrefix] to
-     * the [artifactId][MavenPublication.setArtifactId] of
-     * this publication, if the prefix is not added yet.
+     * The following project attributes are copied:
+     *  * [group][Project.getGroup];
+     *  * [version][Project.getVersion];
+     *  * [description][Project.getDescription].
+     *
+     * Also, this function adds the [artifactPrefix][SpinePublishing.artifactPrefix] to
+     * the [artifactId][MavenPublication.setArtifactId] of this publication,
+     * if the prefix is not added yet.
      */
-    protected fun MavenPublication.assignMavenCoordinates() {
+    protected fun MavenPublication.copyProjectAttributes() {
         groupId = project.group.toString()
         val prefix = project.spinePublishing.artifactPrefix
         if (!artifactId.startsWith(prefix)) {
             artifactId = prefix + artifactId
         }
         version = project.version.toString()
+        pom.description.set(project.description)
     }
 }
 
@@ -117,7 +122,7 @@ private fun RepositoryHandler.register(project: Project, repository: Repository)
 /**
  * A publication for a typical Java project.
  *
- * In Gradle, in order to publish something somewhere one should create a publication.
+ * In Gradle, to publish something, one should create a publication.
  * A publication has a name and consists of one or more artifacts plus information about
  * those artifacts – the metadata.
  *
@@ -149,7 +154,7 @@ internal class StandardJavaPublicationHandler(
         val jars = project.artifacts(jarFlags)
         val publications = project.publications
         publications.create<MavenPublication>("mavenJava") {
-            assignMavenCoordinates()
+            copyProjectAttributes()
             specifyArtifacts(jars)
         }
     }
@@ -198,7 +203,7 @@ internal class StandardJavaPublicationHandler(
  *
  * Such publications should be treated differently than [StandardJavaPublicationHandler],
  * which is <em>created</em> for a module. Instead, since the publications are already declared,
- * this class only [assigns maven coordinates][assignMavenCoordinates].
+ * this class only [assigns maven coordinates][copyProjectAttributes].
  *
  * A module which declares custom publications must be specified in
  * the [SpinePublishing.modulesWithCustomPublishing] property.
@@ -213,7 +218,7 @@ internal class CustomPublicationHandler(project: Project, destinations: Set<Repo
 
     override fun handlePublications() {
         project.publications.forEach {
-            (it as MavenPublication).assignMavenCoordinates()
+            (it as MavenPublication).copyProjectAttributes()
         }
     }
 }

--- a/buildSrc/src/main/kotlin/write-manifest.gradle.kts
+++ b/buildSrc/src/main/kotlin/write-manifest.gradle.kts
@@ -111,7 +111,7 @@ val exposeManifestForTests by tasks.creating {
         val manifest = Manifest()
 
         // The manifest version attribute is crucial for writing.
-        // It it's absent nothing would be written.
+        // If it's absent, nothing would be written.
         manifest.mainAttributes[MANIFEST_VERSION] = "1.0"
 
         manifestAttributes.forEach { entry ->

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.205`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.206`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -636,12 +636,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 15:50:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 21:03:02 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.205`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.206`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1391,12 +1391,12 @@ This report was generated on **Sun Mar 10 15:50:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 15:50:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 21:03:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.205`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.206`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2237,12 +2237,12 @@ This report was generated on **Sun Mar 10 15:50:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 15:50:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 21:03:03 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.205`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.206`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3817,12 +3817,12 @@ This report was generated on **Sun Mar 10 15:50:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 15:50:18 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 21:03:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.205`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.206`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5341,12 +5341,12 @@ This report was generated on **Sun Mar 10 15:50:18 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 15:50:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 21:03:04 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.205`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.206`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5929,12 +5929,12 @@ This report was generated on **Sun Mar 10 15:50:19 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 15:50:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 21:03:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.205`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.206`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6613,4 +6613,4 @@ This report was generated on **Sun Mar 10 15:50:19 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 10 15:50:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 10 21:03:05 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.205</version>
+<version>2.0.0-SNAPSHOT.206</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/psi-java-bundle-jar/build.gradle.kts
+++ b/psi-java-bundle-jar/build.gradle.kts
@@ -41,6 +41,8 @@ val spinePublishing = rootProject.the<SpinePublishing>()
 /** The ID of the far JAR artifact. */
 val projectArtifact = spinePublishing.artifactPrefix + "psi-java-bundle"
 
+project.description = "A fat JAR version of the `spine-psi-java` artifact."
+
 publishing {
     val groupName = project.group.toString()
     val versionName = project.version.toString()

--- a/tool-base/src/main/kotlin/io/spine/tools/code/manifest/KManifest.kt
+++ b/tool-base/src/main/kotlin/io/spine/tools/code/manifest/KManifest.kt
@@ -64,6 +64,15 @@ public class KManifest(public val impl: Manifest) {
         public val DEPENDS_ON_ATTR: Name = Name("Depends-On")
 
         /**
+         * The name of a commonly used manifest attribute,
+         * describing the contents of the respective JAR file.
+         *
+         * This attribute name is hard-coded in [Attributes] as a plain string literal,
+         * therefore, we re-declare it here as a constant.
+         */
+        public val BUNDLE_DESCRIPTION: Name = Name("Bundle-Description")
+
+        /**
          * Loads the manifest next to the given class.
          */
         public fun load(cls: Class<*>): KManifest {
@@ -111,6 +120,11 @@ public class KManifest(public val impl: Manifest) {
      * Obtains the [`Implementation-Vendor`][IMPLEMENTATION_VENDOR] attribute of the manifest.
      */
     public val implementationVendor: String? = mainAttributes[IMPLEMENTATION_VENDOR]?.toString()
+
+    /**
+     * Obtains the [`Bundle-Description`][BUNDLE_DESCRIPTION] attribute of the manifest.
+     */
+    public val bundleDescription: String? = mainAttributes[BUNDLE_DESCRIPTION]?.toString()
 
     /**
      * Obtains the dependencies declared in the ['Depends-On'][DEPENDS_ON_ATTR] attribute

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.205")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.206")


### PR DESCRIPTION
This PR teaches `SpinePublishing` to apply Gradle project description to `pom.xml` file created when publishing the project.

`psi-java-bundle` got the property to overcome the GitHub issue which picks up the description of Guava.

`KManifest` also got the property `bundleDescription` for possible future use.

