### PR TITLE
Bring PSI-related extensions from McJava

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.198"
+        const val base = "2.0.0-SNAPSHOT.199"
 
         /**
          * The version of [Spine.reflect].

--- a/dependencies.md
+++ b/dependencies.md
@@ -636,7 +636,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 31 10:14:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 16:22:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1391,7 +1391,7 @@ This report was generated on **Sun Mar 31 10:14:46 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 31 10:14:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 16:22:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2277,7 +2277,7 @@ This report was generated on **Sun Mar 31 10:14:46 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 31 10:14:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 16:22:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3857,7 +3857,7 @@ This report was generated on **Sun Mar 31 10:14:46 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 31 10:14:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 16:22:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5381,7 +5381,7 @@ This report was generated on **Sun Mar 31 10:14:47 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 31 10:14:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 16:22:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5969,7 +5969,7 @@ This report was generated on **Sun Mar 31 10:14:47 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 31 10:14:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 16:22:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6653,4 +6653,4 @@ This report was generated on **Sun Mar 31 10:14:48 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 31 10:14:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 16:22:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.209`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.208`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -636,12 +636,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 17:15:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 10:14:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.209`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.208`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1391,12 +1391,12 @@ This report was generated on **Sat Mar 30 17:15:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 17:15:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 10:14:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.209`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.208`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2277,12 +2277,12 @@ This report was generated on **Sat Mar 30 17:15:15 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 10:14:46 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.209`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.208`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3857,12 +3857,12 @@ This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 10:14:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.209`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.208`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5381,12 +5381,12 @@ This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 10:14:47 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.209`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.208`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5969,12 +5969,12 @@ This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 10:14:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.209`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.208`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6653,4 +6653,4 @@ This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 17:15:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Mar 31 10:14:48 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.207`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -636,12 +636,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 27 19:22:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 04:14:09 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.207`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1391,12 +1391,12 @@ This report was generated on **Wed Mar 27 19:22:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 27 19:22:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 04:14:09 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.207`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2277,12 +2277,12 @@ This report was generated on **Wed Mar 27 19:22:17 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 27 19:22:18 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 04:14:09 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.207`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3857,12 +3857,12 @@ This report was generated on **Wed Mar 27 19:22:18 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 27 19:22:18 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.207`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5381,12 +5381,12 @@ This report was generated on **Wed Mar 27 19:22:18 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 27 19:22:18 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.207`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5969,12 +5969,12 @@ This report was generated on **Wed Mar 27 19:22:18 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 27 19:22:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.207`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.209`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6653,4 +6653,4 @@ This report was generated on **Wed Mar 27 19:22:19 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 27 19:22:19 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -636,7 +636,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 04:14:09 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 17:15:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1391,7 +1391,7 @@ This report was generated on **Sat Mar 30 04:14:09 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 04:14:09 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 17:15:15 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2277,7 +2277,7 @@ This report was generated on **Sat Mar 30 04:14:09 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 04:14:09 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3857,7 +3857,7 @@ This report was generated on **Sat Mar 30 04:14:09 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5381,7 +5381,7 @@ This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5969,7 +5969,7 @@ This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 17:15:16 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6653,4 +6653,4 @@ This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Mar 30 04:14:10 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 30 17:15:17 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.209</version>
+<version>2.0.0-SNAPSHOT.208</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.207</version>
+<version>2.0.0-SNAPSHOT.209</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -146,7 +146,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.198</version>
+    <version>2.0.0-SNAPSHOT.199</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
@@ -78,21 +78,21 @@ public val PsiClass.modifiers: PsiModifierList
  */
 @Deprecated("Please use `PsiModifierListOwner.isPublic` instead.")
 public val PsiClass.isPublic: Boolean
-    get() = modifiers.hasModifierProperty(PUBLIC)
+    get() = (this as PsiModifierListOwner).isPublic
 
 /**
  * Tells if this class has the [`static`][STATIC] modifier.
  */
 @Deprecated("Please use `PsiModifierListOwner.isStatic` instead.")
 public val PsiClass.isStatic: Boolean
-    get() = modifiers.hasModifierProperty(STATIC)
+    get() = (this as PsiModifierListOwner).isStatic
 
 /**
  * Tells if this class has the [`final`][FINAL] modifier.
  */
 @Deprecated("Please use `PsiModifierListOwner.isFinal` instead.")
 public val PsiClass.isFinal: Boolean
-    get() = modifiers.hasModifierProperty(FINAL)
+    get() = (this as PsiModifierListOwner).isFinal
 
 /**
  * Adds `static` modifier to this class, if it did not have the modifier before.

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
@@ -33,6 +33,7 @@ import com.intellij.psi.PsiModifier.FINAL
 import com.intellij.psi.PsiModifier.PUBLIC
 import com.intellij.psi.PsiModifier.STATIC
 import com.intellij.psi.PsiModifierList
+import com.intellij.psi.PsiModifierListOwner
 import io.spine.tools.psi.document
 
 /**
@@ -75,44 +76,44 @@ public val PsiClass.modifiers: PsiModifierList
 /**
  * Tells if this class has the [`public`][PUBLIC] modifier.
  */
+@Deprecated("Please use `PsiModifierListOwner.isPublic` instead.")
 public val PsiClass.isPublic: Boolean
     get() = modifiers.hasModifierProperty(PUBLIC)
 
 /**
  * Tells if this class has the [`static`][STATIC] modifier.
  */
+@Deprecated("Please use `PsiModifierListOwner.isStatic` instead.")
 public val PsiClass.isStatic: Boolean
     get() = modifiers.hasModifierProperty(STATIC)
 
 /**
  * Tells if this class has the [`final`][FINAL] modifier.
  */
+@Deprecated("Please use `PsiModifierListOwner.isFinal` instead.")
 public val PsiClass.isFinal: Boolean
     get() = modifiers.hasModifierProperty(FINAL)
 
 /**
  * Adds `static` modifier to this class, if it did not have the modifier before.
  */
-public fun PsiClass.makeStatic(): PsiClass {
-    modifiers.setIfAbsent(STATIC)
-    return this
-}
+@Deprecated("Please use `PsiModifierListOwner.makeStatic()` instead.")
+public fun PsiClass.makeStatic(): PsiClass =
+    (this as PsiModifierListOwner).makeStatic() as PsiClass
 
 /**
  * Adds `public` modifier to this class, if it did not have the modifier before.
  */
-public fun PsiClass.makePublic(): PsiClass {
-    modifiers.setIfAbsent(PUBLIC)
-    return this
-}
+@Deprecated("Please use `PsiModifierListOwner.makePublic()` instead.")
+public fun PsiClass.makePublic(): PsiClass =
+    (this as PsiModifierListOwner).makePublic() as PsiClass
 
 /**
  * Adds `final` modifier to this class, if it did not have the modifier before.
  */
-public fun PsiClass.makeFinal(): PsiClass {
-    modifiers.setIfAbsent(FINAL)
-    return this
-}
+@Deprecated("Please use `PsiModifierListOwner.makeFinal()` instead.")
+public fun PsiClass.makeFinal(): PsiClass =
+    (this as PsiModifierListOwner).makeFinal() as PsiClass
 
 /**
  * Adds given [element] before the [firstChild][PsiClass.getFirstChild] of this class.

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
@@ -29,6 +29,8 @@ package io.spine.tools.psi.java
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier.FINAL
+import com.intellij.psi.PsiModifier.PUBLIC
 import com.intellij.psi.PsiModifier.STATIC
 import com.intellij.psi.PsiModifierList
 import io.spine.tools.psi.document
@@ -71,10 +73,22 @@ public val PsiClass.modifiers: PsiModifierList
     }
 
 /**
+ * Tells if this class has the [`public`][PUBLIC] modifier.
+ */
+public val PsiClass.isPublic: Boolean
+    get() = modifiers.hasModifierProperty(PUBLIC)
+
+/**
  * Tells if this class has the [`static`][STATIC] modifier.
  */
 public val PsiClass.isStatic: Boolean
     get() = modifiers.hasModifierProperty(STATIC)
+
+/**
+ * Tells if this class has the [`final`][FINAL] modifier.
+ */
+public val PsiClass.isFinal: Boolean
+    get() = modifiers.hasModifierProperty(FINAL)
 
 /**
  * Adds `static` modifier to this class, if it did not have the modifier before.
@@ -82,6 +96,29 @@ public val PsiClass.isStatic: Boolean
 public fun PsiClass.makeStatic(): PsiClass {
     modifiers.setIfAbsent(STATIC)
     return this
+}
+
+/**
+ * Adds `public` modifier to this class, if it did not have the modifier before.
+ */
+public fun PsiClass.makePublic(): PsiClass {
+    modifiers.setIfAbsent(PUBLIC)
+    return this
+}
+
+/**
+ * Adds `final` modifier to this class, if it did not have the modifier before.
+ */
+public fun PsiClass.makeFinal(): PsiClass {
+    modifiers.setIfAbsent(FINAL)
+    return this
+}
+
+/**
+ * Adds given [element] before the [firstChild][PsiClass.getFirstChild] of this class.
+ */
+public fun PsiClass.addFirst(element: PsiElement): PsiElement {
+    return addBefore(element, firstChild)
 }
 
 /**

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
@@ -74,48 +74,6 @@ public val PsiClass.modifiers: PsiModifierList
     }
 
 /**
- * Tells if this class has the [`public`][PUBLIC] modifier.
- */
-@Deprecated("Please use `PsiModifierListOwner.isPublic` instead.")
-public val PsiClass.isPublic: Boolean
-    get() = (this as PsiModifierListOwner).isPublic
-
-/**
- * Tells if this class has the [`static`][STATIC] modifier.
- */
-@Deprecated("Please use `PsiModifierListOwner.isStatic` instead.")
-public val PsiClass.isStatic: Boolean
-    get() = (this as PsiModifierListOwner).isStatic
-
-/**
- * Tells if this class has the [`final`][FINAL] modifier.
- */
-@Deprecated("Please use `PsiModifierListOwner.isFinal` instead.")
-public val PsiClass.isFinal: Boolean
-    get() = (this as PsiModifierListOwner).isFinal
-
-/**
- * Adds `static` modifier to this class, if it did not have the modifier before.
- */
-@Deprecated("Please use `PsiModifierListOwner.makeStatic()` instead.")
-public fun PsiClass.makeStatic(): PsiClass =
-    (this as PsiModifierListOwner).makeStatic() as PsiClass
-
-/**
- * Adds `public` modifier to this class, if it did not have the modifier before.
- */
-@Deprecated("Please use `PsiModifierListOwner.makePublic()` instead.")
-public fun PsiClass.makePublic(): PsiClass =
-    (this as PsiModifierListOwner).makePublic() as PsiClass
-
-/**
- * Adds `final` modifier to this class, if it did not have the modifier before.
- */
-@Deprecated("Please use `PsiModifierListOwner.makeFinal()` instead.")
-public fun PsiClass.makeFinal(): PsiClass =
-    (this as PsiModifierListOwner).makeFinal() as PsiClass
-
-/**
  * Adds given [element] before the [firstChild][PsiClass.getFirstChild] of this class.
  */
 public fun PsiClass.addFirst(element: PsiElement): PsiElement {

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementFactoryExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementFactoryExts.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.psi.java
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElementFactory
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.javadoc.PsiDocComment
+import io.spine.tools.psi.java.Environment.elementFactory
+import org.jetbrains.annotations.TestOnly
+
+public fun PsiElementFactory.createPrivateConstructor(
+    cls: PsiClass,
+    javadocText: String? = null,
+    body: String? = null,
+): PsiMethod {
+    val ctor = createMethodFromText("""
+        private ${cls.name}() {
+            // No-op.
+        }            
+        """.trimIndent(), cls
+    )
+    if (javadocText != null) {
+        val javadoc = createJavadoc(javadocText)
+        ctor.addBefore(javadoc, ctor.firstChild)
+    }
+    return ctor
+}
+
+public fun PsiElementFactory.createJavadoc(text: String): PsiDocComment {
+    require(text.isNotEmpty()) {
+        "Unable to create a Javadoc comment with an empty text."
+    }
+    //TODO:2024-03-31:alexander.yevsyukov: See if the comment multiline, and use
+    // proper surrounding accordingly.
+    val javadoc = createDocCommentFromText(
+        """
+        /** Prevents instantiation of this class. */    
+        """.trimIndent()
+    )
+    return javadoc
+}
+
+/**
+ * Creates a no-op method which returns `void`.
+ *
+ * Use this extension for creating stub instances of [PsiMethod] for code generation tests.
+ */
+@TestOnly
+public fun PsiElementFactory.createStubMethod(name: String): PsiMethod {
+    val method = createMethodFromText("""
+            void $name() {}
+            """.trimIndent(), null
+    )
+    return method
+}

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExts.kt
@@ -29,6 +29,7 @@ package io.spine.tools.psi.java
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiModifier.FINAL
 import com.intellij.psi.PsiModifier.PUBLIC
+import com.intellij.psi.PsiModifier.PRIVATE
 import com.intellij.psi.PsiModifier.STATIC
 import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiModifierListOwner
@@ -53,6 +54,12 @@ public val PsiModifierListOwner.isFinal: Boolean
  */
 public val PsiModifierListOwner.isPublic: Boolean
     get() = hasModifier(PUBLIC)
+
+/**
+ * Returns `true` if the modifier [`private`][PRIVATE] is applied.
+ */
+public val PsiModifierListOwner.isPrivate: Boolean
+    get() = hasModifier(PRIVATE)
 
 /**
  * Tells if this class has the [`static`][STATIC] modifier.

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExts.kt
@@ -29,21 +29,37 @@ package io.spine.tools.psi.java
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiModifier.FINAL
 import com.intellij.psi.PsiModifier.PUBLIC
+import com.intellij.psi.PsiModifier.STATIC
 import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiModifierListOwner
 import org.jetbrains.annotations.NonNls
 
 /**
+ * Tells if this object has the modifier with the given [name].
+ */
+public fun PsiModifierListOwner.hasModifier(
+    @PsiModifier.ModifierConstant @NonNls name: String): Boolean {
+    return  modifierList?.hasModifierProperty(name) ?: false
+}
+
+/**
  * Returns `true` if the modifier [`final`][FINAL] is applied.
  */
 public val PsiModifierListOwner.isFinal: Boolean
-    get() = modifierList?.hasModifierProperty(FINAL) ?: false
+    get() = hasModifier(FINAL)
 
 /**
  * Returns `true` if the modifier [`public`][PUBLIC] is applied.
  */
 public val PsiModifierListOwner.isPublic: Boolean
-    get() = modifierList?.hasModifierProperty(PUBLIC) ?: false
+    get() = hasModifier(PUBLIC)
+
+/**
+ * Tells if this class has the [`static`][STATIC] modifier.
+ */
+public val PsiModifierListOwner.isStatic: Boolean
+    get() = hasModifier(STATIC)
+
 
 /**
  * Adds the [`public`][PUBLIC] modifier.
@@ -58,6 +74,14 @@ public fun PsiModifierListOwner.makePublic(): PsiModifierListOwner {
  */
 public fun PsiModifierListOwner.makeFinal(): PsiModifierListOwner {
     modifierList?.setIfAbsent(FINAL)
+    return this
+}
+
+/**
+ * Adds the [`static`][STATIC] modifier.
+ */
+public fun PsiModifierListOwner.makeStatic(): PsiModifierListOwner {
+    modifierList?.setIfAbsent(STATIC)
     return this
 }
 

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExts.kt
@@ -62,7 +62,7 @@ public val PsiModifierListOwner.isPrivate: Boolean
     get() = hasModifier(PRIVATE)
 
 /**
- * Tells if this class has the [`static`][STATIC] modifier.
+ * Returns `true` if the modifier [`static`][STATIC] is applied.
  */
 public val PsiModifierListOwner.isStatic: Boolean
     get() = hasModifier(STATIC)

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementFactoryExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementFactoryExtsSpec.kt
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-@DisplayName("Extensions for `PsiElementFactory` should")
+@DisplayName("`PsiElementFactory` extensions should")
 internal class PsiElementFactoryExtsSpec {
 
     @Nested inner class

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementFactoryExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementFactoryExtsSpec.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.psi.java
+
+import com.intellij.psi.javadoc.PsiDocComment
+import io.kotest.matchers.shouldBe
+import io.spine.testing.TestValues.randomString
+import io.spine.tools.psi.java.Environment.elementFactory
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("Extensions for `PsiElementFactory` should")
+internal class PsiElementFactoryExtsSpec {
+
+    @Nested inner class
+    `create one-line Javadoc` {
+
+        @Test
+        fun `with the given content`() {
+            val line = randomString()
+            val javadoc = elementFactory.createJavadoc(line)
+            javadoc.text shouldBe "/** $line */"
+        }
+
+        @Test
+        fun `prohibiting empty Javadoc`() {
+            assertThrows<IllegalArgumentException> {
+                elementFactory.createJavadoc("")
+            }
+        }
+
+        /**
+         * We do not allow multi-line Javadoc comments passed to the utility under the tests
+         * to encourage using [com.intellij.psi.PsiElementFactory.createDocCommentFromText]
+         * method directly when more advanced Javadoc is needed.
+         *
+         * We do this to avoid formatting and other possible issues which could occur, had
+         * we allowed multi-line comments without surrounding slashes and star symbols.
+         */
+        @Test
+        fun `prohibiting multi-line Javadoc`() {
+            assertThrows<IllegalArgumentException> {
+                elementFactory.createJavadoc("line1.\nline2.")
+            }
+        }
+    }
+
+    @Nested inner class
+    `create private constructor` {
+
+        private val className = "StubClass"
+        private val cls = elementFactory.createClass(className)
+
+        @Test
+        fun `for the given class`() {
+            val ctor = elementFactory.createPrivateConstructor(cls)
+
+            ctor.name shouldBe className
+            ctor.isPrivate shouldBe true
+        }
+
+        @Test
+        fun `with Javadoc one-line comment`() {
+            val line = randomString()
+
+            val ctor = elementFactory.createPrivateConstructor(cls, line)
+            val javadoc = ctor.children.first()
+            (javadoc is PsiDocComment) shouldBe true
+            javadoc.text shouldBe "/** $line */"
+        }
+
+        @Test
+        fun `prohibiting empty Javadoc`() {
+            assertThrows<IllegalArgumentException> {
+                elementFactory.createPrivateConstructor(cls, "")
+            }
+        }
+
+        @Test
+        fun `prohibiting multi-line Javadoc`() {
+            assertThrows<IllegalArgumentException> {
+                elementFactory.createPrivateConstructor(cls, "line1.\nline2.")
+            }
+        }
+    }
+}

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExtsSpec.kt
@@ -26,7 +26,7 @@
 
 package io.spine.tools.psi.java
 
-import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiModifierListOwner
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test
 @DisplayName("`PsiModifierListOwner` extensions should")
 class PsiModifierListOwnerExtsSpec {
 
-    private lateinit var cls: PsiClass
+    private lateinit var cls: PsiModifierListOwner
 
     @BeforeEach
     fun createClass() {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.207")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.209")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.209")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.208")


### PR DESCRIPTION
This PR brings extensions to PSI classes previously adopted in McJava.

### Extensions for `PsiClass`
 * `addFirst()`.

### Extensions for `PsiElementFactory`
 * `createPrivateConstructor()`
 * `createJavadoc()`
 * `createStubMethod()`.

### Extensions for `PsiModifierListOwner`
 * `hasModifier()`
 * `isPrivate`
 * `isStatic` — now serves instead of `PsiClass.isStatic`, which was removed.
 * `makeStatic()` — now serves instead of `PsiClass.makeStatic()`, which was removed.
