### PR TITLE
Introduce `Ordered` wrapper for `ListProperty`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.216`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.217`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -661,12 +661,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 28 19:48:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 29 21:40:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.216`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.217`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1438,12 +1438,12 @@ This report was generated on **Fri Jun 28 19:48:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 28 19:48:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 29 21:40:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.216`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.217`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2358,12 +2358,12 @@ This report was generated on **Fri Jun 28 19:48:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 28 19:48:10 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 29 21:40:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.216`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.217`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3980,12 +3980,12 @@ This report was generated on **Fri Jun 28 19:48:10 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 28 19:48:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.216`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.217`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5537,12 +5537,12 @@ This report was generated on **Fri Jun 28 19:48:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 28 19:48:11 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.216`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.217`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6147,12 +6147,12 @@ This report was generated on **Fri Jun 28 19:48:11 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 28 19:48:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.216`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.217`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6862,4 +6862,4 @@ This report was generated on **Fri Jun 28 19:48:12 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 28 19:48:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/Multiple.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/Multiple.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -44,9 +44,9 @@ public class Multiple<E : Any>
  * Creates a new `Multiple`.
  *
  * @param project
- *          the project which provides an object factory for creating Gradle properties
+ *          the project which provides an object factory for creating Gradle properties.
  * @param klass
- *          class of the elements of the set
+ *          the class of the elements in the set.
  */
 constructor(
     project: Project, klass: KClass<E>
@@ -58,16 +58,16 @@ constructor(
      * This is a Java-friendly constructor. Use the primary constructor in Kotlin.
      *
      * @param project
-     *          the project which provides an object factory for creating Gradle properties
+     *          the project which provides an object factory for creating Gradle properties.
      * @param cls
-     *          Java class of the elements of the set
+     *          the Java class of the elements in the set.
      */
     public constructor(project: Project, cls: Class<E>) : this(project, cls.kotlin)
 
     /**
      * Obtains the value of this property and applies the given mapping function to each element.
      *
-     * @param T target type of the transformation
+     * @param T target type of the transformation.
      */
     public fun <T> transform(transformer: (E) -> T): ImmutableSet<T> =
         get().map(transformer).toImmutableSet()

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/Ordered.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/Ordered.kt
@@ -26,35 +26,35 @@
 
 package io.spine.tools.gradle
 
-import com.google.common.collect.ImmutableSet
+import com.google.common.collect.ImmutableList
 import io.spine.annotation.Internal
 import kotlin.reflect.KClass
 import org.gradle.api.Project
-import org.gradle.api.provider.SetProperty
+import org.gradle.api.provider.ListProperty
 
 /**
- * A Gradle [SetProperty] which is automatically instantiated by
+ * A Gradle [ListProperty] which is automatically instantiated by
  * the [ObjectFactory][org.gradle.api.model.ObjectFactory] of the associated project.
  *
- * @param E the type of the elements in the set.
+ * @param E the type of the elements in the list.
  * @param project
  *         the project which provides an object factory for creating Gradle properties.
  * @param klass
- *         the class of the elements in the set.
+ *         the class of the elements in the list.
  */
 @Internal
-public class Multiple<E : Any>(project: Project, klass: KClass<E>) :
-    SetProperty<E> by project.objects.setProperty(klass.java) {
+public class Ordered<E : Any>(project: Project, klass: KClass<E>) :
+    ListProperty<E> by project.objects.listProperty(klass.java) {
 
     /**
-     * Creates a new `Multiple`.
+     * Creates a new `Ordered`.
      *
      * This is a Java-friendly constructor. Use the primary constructor in Kotlin.
      *
      * @param project
      *         the project which provides an object factory for creating Gradle properties.
      * @param cls
-     *         the Java class of the elements in the set.
+     *         the Java class of the elements in the list.
      */
     public constructor(project: Project, cls: Class<E>) : this(project, cls.kotlin)
 
@@ -63,8 +63,8 @@ public class Multiple<E : Any>(project: Project, klass: KClass<E>) :
      *
      * @param T the target type of the transformation.
      */
-    public fun <T> transform(transformer: (E) -> T): ImmutableSet<T> =
-        get().map(transformer).toImmutableSet()
+    public fun <T> transform(transformer: (E) -> T): ImmutableList<T> =
+        get().map(transformer).toImmutableList()
 }
 
-private fun <T> Iterable<T>.toImmutableSet(): ImmutableSet<T> = ImmutableSet.copyOf(this)
+private fun <T> Iterable<T>.toImmutableList(): ImmutableList<T> = ImmutableList.copyOf(this)

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/MultipleSpec.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/MultipleSpec.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle
+
+import io.kotest.matchers.collections.shouldContainExactly
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`Multiple` should")
+internal class MultipleSpec {
+
+    private val project = ProjectBuilder.builder().build()
+
+    @Test
+    fun `be created using Kotlin class`() {
+        val m = Multiple(project, String::class)
+        val expected = setOf("1", "2", "3")
+        m.set(expected)
+        m.get() shouldContainExactly expected
+    }
+
+    @Test
+    fun `be created using Java class`() {
+        val m = Multiple(project, String::class.java)
+        val expected = setOf("um", "dois", "três")
+        m.set(expected)
+        m.get() shouldContainExactly expected
+    }
+
+    @Test
+    fun `run transformation`() {
+        val m = Multiple(project, Int::class)
+        m.set(setOf(1, 2, 3))
+        m.transform { it * 2 } shouldContainExactly setOf(2, 4, 6)
+    }
+}

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/OrderedSpec.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/OrderedSpec.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle
+
+import io.kotest.matchers.collections.shouldContainInOrder
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`Ordered` should")
+internal class OrderedSpec {
+
+    private val project = ProjectBuilder.builder().build()
+
+    @Test
+    fun `be created using Kotlin class`() {
+        val m = Ordered(project, String::class)
+        val expected = listOf("apple", "orange", "banana")
+        m.set(expected)
+        m.get() shouldContainInOrder expected
+    }
+
+    @Test
+    fun `be created using Java class`() {
+        val m = Ordered(project, String::class.java)
+        val expected = listOf("Espresso", "Breve", "Cappuccino", "Latte")
+        m.set(expected)
+        m.get() shouldContainInOrder expected
+    }
+
+    @Test
+    fun `run transformation`() {
+        val m = Ordered(project, Int::class)
+        m.set(listOf(1, 2, 3))
+        m.transform { it * it } shouldContainInOrder listOf(1, 4, 9)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.216</version>
+<version>2.0.0-SNAPSHOT.217</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.216")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.217")


### PR DESCRIPTION
This PR adds the `Ordered` class which is implementation of Gradle's `ListProperty`. The class is to accompany earlier introduced `Multiple` implementation of the `SetProperty` interface but for the cases when the order of items is important.
