### PR TITLE
`PsiClass` extensions for implementing interfaces

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.217`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.218`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -661,12 +661,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 29 21:40:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 21:13:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.217`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.218`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -1438,12 +1438,12 @@ This report was generated on **Sat Jun 29 21:40:37 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 29 21:40:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 21:13:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.217`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.218`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2358,12 +2358,12 @@ This report was generated on **Sat Jun 29 21:40:37 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 29 21:40:37 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 21:13:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.217`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.218`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3980,12 +3980,12 @@ This report was generated on **Sat Jun 29 21:40:37 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 21:13:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.217`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.218`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5537,12 +5537,12 @@ This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 21:13:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.217`
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.218`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6147,12 +6147,12 @@ This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 21:13:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.217`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.218`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6862,4 +6862,4 @@ This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 29 21:40:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 20 21:13:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.217</version>
+<version>2.0.0-SNAPSHOT.218</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
@@ -154,6 +154,15 @@ public fun PsiClass.setSuperclass(superClass: PsiJavaCodeReferenceElement) {
 }
 
 /**
+ * Tells if this class or interface implements one or more interfaces.
+ */
+public fun PsiClass.implementsInterfaces(): Boolean {
+    // It's not likely that `implementsList` is `null`, but this way we cover possible future
+    // changes in the PSI implementation.
+    return implementsList?.referenceElements?.isNotEmpty() ?: false
+}
+
+/**
  * Makes a Java class or interface represented by this [PsiClass] implement the given interface.
  *
  * If this class or interface already implements the interface, the function does nothing.

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
@@ -121,7 +121,7 @@ public val PsiClass.explicitSuperclass: PsiJavaCodeReferenceElement?
  *          if called for a receiver representing an anonymous class, or
  *          when the receiver already extends another class.
  * @see setSuperclass
- * @see implementInterface
+ * @see implement
  */
 @Deprecated(
     message = "Please use `setSuperclass()` instead.",
@@ -137,7 +137,7 @@ public fun PsiClass.addSuperclass(superClass: PsiJavaCodeReferenceElement) {
  * @throws IllegalStateException
  *          if called for a receiver representing an anonymous class, or
  *          when the receiver already extends another class.
- * @see implementInterface
+ * @see implement
  */
 public fun PsiClass.setSuperclass(superClass: PsiJavaCodeReferenceElement) {
     check(extendsList != null) {
@@ -154,7 +154,7 @@ public fun PsiClass.setSuperclass(superClass: PsiJavaCodeReferenceElement) {
 }
 
 /**
- * Tells if this class or interface implements one or more interfaces.
+ * Tells if this class implements one or more interfaces.
  */
 public fun PsiClass.implementsInterfaces(): Boolean {
     // It's not likely that `implementsList` is `null`, but this way we cover possible future
@@ -163,23 +163,30 @@ public fun PsiClass.implementsInterfaces(): Boolean {
 }
 
 /**
- * Makes a Java class or interface represented by this [PsiClass] implement the given interface.
+ * Tells if this class implements the given interface.
+ */
+@JvmName("doesImplement")
+public fun PsiClass.implements(superInterface: PsiJavaCodeReferenceElement): Boolean {
+    return implementsList?.referenceElements?.any {
+        it.qualifiedName == superInterface.qualifiedName
+    } ?: false
+}
+
+/**
+ * Makes a Java class represented by this [PsiClass] implement the given interface.
  *
  * If this class or interface already implements the interface, the function does nothing.
  *
  * @see setSuperclass
  */
-public fun PsiClass.implementInterface(superInterface: PsiJavaCodeReferenceElement) {
+public fun PsiClass.implement(superInterface: PsiJavaCodeReferenceElement) {
     val implements = implementsList
     if (implements == null) {
         val newList = elementFactory.createReferenceList(arrayOf(superInterface))
         addBefore(newList, lBrace)
         return
     }
-    val alreadyImplements = implements.referenceElements.any {
-        it.qualifiedName == superInterface.qualifiedName
-    }
-    if (!alreadyImplements) {
+    if (!implements(superInterface)) {
         implements.add(superInterface)
     }
 }

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementFactoryExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementFactoryExts.kt
@@ -124,6 +124,7 @@ public inline fun <reified T: Any> PsiElementFactory.createClassType(): PsiClass
  *         optional generic parameters if the class to reference is generic.
  * @return new class reference.
  */
+@JvmName("createClassReference")
 public fun PsiElementFactory.createClassReference(
     context: PsiElement? = null,
     className: String,

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiJavaFileExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiJavaFileExts.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -61,10 +61,10 @@ public fun PsiJavaFile.locate(simpleName: Iterable<String>): PsiClass? {
     require(names.isNotEmpty()) {
         "The list of simple class names must not be empty."
     }
-    // There's only one top level class in a Java file.
+    // There's only one top-level class in a Java file.
     val topLevel = classes.first()
     if (topLevel.name != names[0]) {
-        // The top level class in the file does not match the first simple name.
+        // The top-level class in the file does not match the first simple name.
         // No need to look further.
         return null
     }

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiModifierListOwnerExts.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -26,10 +26,11 @@
 
 package io.spine.tools.psi.java
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiModifier.FINAL
-import com.intellij.psi.PsiModifier.PUBLIC
 import com.intellij.psi.PsiModifier.PRIVATE
+import com.intellij.psi.PsiModifier.PUBLIC
 import com.intellij.psi.PsiModifier.STATIC
 import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiModifierListOwner
@@ -71,6 +72,7 @@ public val PsiModifierListOwner.isStatic: Boolean
 /**
  * Adds the [`public`][PUBLIC] modifier.
  */
+@CanIgnoreReturnValue
 public fun PsiModifierListOwner.makePublic(): PsiModifierListOwner {
     modifierList?.setIfAbsent(PUBLIC)
     return this
@@ -79,6 +81,7 @@ public fun PsiModifierListOwner.makePublic(): PsiModifierListOwner {
 /**
  * Adds the [`final`][FINAL] modifier.
  */
+@CanIgnoreReturnValue
 public fun PsiModifierListOwner.makeFinal(): PsiModifierListOwner {
     modifierList?.setIfAbsent(FINAL)
     return this
@@ -87,6 +90,7 @@ public fun PsiModifierListOwner.makeFinal(): PsiModifierListOwner {
 /**
  * Adds the [`static`][STATIC] modifier.
  */
+@CanIgnoreReturnValue
 public fun PsiModifierListOwner.makeStatic(): PsiModifierListOwner {
     modifierList?.setIfAbsent(STATIC)
     return this
@@ -95,6 +99,7 @@ public fun PsiModifierListOwner.makeStatic(): PsiModifierListOwner {
 /**
  * Removes the [`public`][PUBLIC] modifier.
  */
+@CanIgnoreReturnValue
 public fun PsiModifierListOwner.removePublic(): PsiModifierListOwner {
     modifierList?.setModifierProperty(PUBLIC, false)
     return this

--- a/psi-java/src/test/java/io/spine/tools/psi/java/PsiClassExtsJavaApiSpec.java
+++ b/psi-java/src/test/java/io/spine/tools/psi/java/PsiClassExtsJavaApiSpec.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.psi.java;
+
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElementFactory;
+import com.intellij.psi.PsiJavaCodeReferenceElement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.tools.psi.java.PsiClassExtsKt.implement;
+import static io.spine.tools.psi.java.PsiCommandsKt.execute;
+import static io.spine.tools.psi.java.PsiClassExtsKt.doesImplement;
+import static io.spine.tools.psi.java.PsiElementFactoryExtsKt.createClassReference;
+import static io.spine.tools.psi.java.PsiModifierListOwnerExtsKt.removePublic;
+
+@DisplayName("`PsiClass` extensions Java API should")
+class PsiClassExtsJavaApiSpec {
+
+    private static final PsiElementFactory elementFactory =
+            Environment.INSTANCE.getElementFactory();
+
+    private PsiClass cls;
+
+    private final PsiJavaCodeReferenceElement runnable =
+            createClassReference(elementFactory, null, Runnable.class.getCanonicalName());
+
+    @BeforeEach
+    void createClass() {
+        cls = elementFactory.createClass("Stub");
+        // Remove the `public` modifier automatically added by the `ElementFactory`.
+        // We need a "bare-bones" class in the tests.
+        execute(() -> removePublic(cls));
+    }
+
+    @Test
+    @DisplayName("provide alias for `implements` function")
+    void methodAlias() {
+        assertThat(doesImplement(cls, runnable)).isFalse();
+
+        execute(() -> implement(cls, runnable));
+
+        assertThat(doesImplement(cls, runnable)).isTrue();
+    }
+}

--- a/psi-java/src/test/java/io/spine/tools/psi/java/package-info.java
+++ b/psi-java/src/test/java/io/spine/tools/psi/java/package-info.java
@@ -24,17 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.tools.psi.java
-
-import com.intellij.openapi.command.CommandProcessor
-import io.spine.tools.psi.java.Environment.commandProcessor
-import io.spine.tools.psi.java.Environment.project
-
 /**
- * Executes the given [Runnable] as a PSI modification
- * [command][CommandProcessor.executeCommand].
+ * Tests in this package cover using PSI extensions from Java code.
  */
-@JvmName("execute")
-public fun execute(runnable: Runnable) {
-    commandProcessor.executeCommand(project, runnable, null, null)
-}
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.tools.psi.java;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
@@ -49,6 +49,8 @@ internal class PsiClassExtsSpec: PsiTest() {
     @BeforeEach
     fun createClass() {
         cls = elementFactory.createClass("Stub")
+        // Remove the `public` modifier automatically added by the `ElementFactory`.
+        // We need a "bare-bones" class in the tests.
         execute { cls.removePublic() }
     }
 
@@ -97,7 +99,46 @@ internal class PsiClassExtsSpec: PsiTest() {
     }
 
     @Nested inner class
-    `Add super type` {
+    `set superclass` {
+
+        private val arrayList: PsiJavaCodeReferenceElement by lazy {
+            elementFactory.createClassReference(
+                className = java.util.ArrayList::class.java.reference
+            )
+        }
+
+        private val hashMap: PsiJavaCodeReferenceElement by lazy {
+            elementFactory.createClassReference(
+                className = java.util.HashMap::class.java.reference
+            )
+        }
+
+        @Test
+        fun `if the class does not have an explicit superclass`() {
+            cls.run {
+                hasSuperclass() shouldBe false
+                execute {
+                    setSuperclass(arrayList)
+                }
+                explicitSuperclass shouldNotBe null
+                explicitSuperclass!!.qualifiedName shouldBe
+                        java.util.ArrayList::class.java.reference
+            }
+        }
+
+        @Test
+        fun `preventing adding if a superclass is already defined`() {
+            execute {
+                cls.setSuperclass(hashMap)
+                assertThrows<IllegalStateException> {
+                    cls.setSuperclass(arrayList)
+                }
+            }
+        }
+    }
+
+    @Nested inner class
+    `make a class or interface implement an interface` {
 
         private val runnable: PsiJavaCodeReferenceElement by lazy {
             elementFactory.createClassReference(className = Runnable::class.java.reference)
@@ -110,24 +151,59 @@ internal class PsiClassExtsSpec: PsiTest() {
         }
 
         @Test
-        fun `if the class does not have a super type`() {
-            cls.run {
-                hasSuperclass() shouldBe false
-                execute {
-                    setSuperclass(runnable)
-                }
-                explicitSuperclass shouldNotBe null
-                explicitSuperclass!!.qualifiedName shouldBe Runnable::class.java.reference
+        fun `if no interfaces are implemented`() {
+            cls.implementsInterfaces() shouldBe false
+
+            execute {
+                cls.implementInterface(runnable)
+            }
+
+            cls.implementsList.run {
+                this shouldNotBe null
+                this!!
+                referenceElements.size shouldBe 1
+                referenceElements[0].qualifiedName shouldBe runnable.qualifiedName
             }
         }
 
         @Test
-        fun `preventing adding if superclass already exists`() {
+        fun `if an interface already implemented`() {
+            cls.implementsInterfaces() shouldBe false
             execute {
-                cls.setSuperclass(function)
-                assertThrows<IllegalStateException> {
-                    cls.setSuperclass(runnable)
+                cls.implementInterface(runnable)
+            }
+
+            assertDoesNotThrow {
+                execute {
+                    cls.implementInterface(runnable)
                 }
+            }
+
+            cls.implementsList.run {
+                this!!
+                referenceElements.size shouldBe 1
+                referenceElements[0].qualifiedName shouldBe runnable.qualifiedName
+            }
+        }
+
+        @Test
+        fun `if another interface is already implemented`() {
+            cls.implementsInterfaces() shouldBe false
+            execute {
+                cls.implementInterface(runnable)
+            }
+
+            assertDoesNotThrow {
+                execute {
+                    cls.implementInterface(function)
+                }
+            }
+
+            cls.implementsList.run {
+                this!!
+                referenceElements.size shouldBe 2
+                referenceElements[0].qualifiedName shouldBe runnable.qualifiedName
+                referenceElements[1].qualifiedName shouldBe function.qualifiedName
             }
         }
     }

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
@@ -114,7 +114,7 @@ internal class PsiClassExtsSpec: PsiTest() {
             cls.run {
                 hasSuperclass() shouldBe false
                 execute {
-                    addSuperclass(runnable)
+                    setSuperclass(runnable)
                 }
                 explicitSuperclass shouldNotBe null
                 explicitSuperclass!!.qualifiedName shouldBe Runnable::class.java.reference
@@ -124,9 +124,9 @@ internal class PsiClassExtsSpec: PsiTest() {
         @Test
         fun `preventing adding if superclass already exists`() {
             execute {
-                cls.addSuperclass(function)
+                cls.setSuperclass(function)
                 assertThrows<IllegalStateException> {
-                    cls.addSuperclass(runnable)
+                    cls.setSuperclass(runnable)
                 }
             }
         }

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
@@ -155,7 +155,7 @@ internal class PsiClassExtsSpec: PsiTest() {
             cls.implementsInterfaces() shouldBe false
 
             execute {
-                cls.implementInterface(runnable)
+                cls.implement(runnable)
             }
 
             cls.implementsList.run {
@@ -170,12 +170,12 @@ internal class PsiClassExtsSpec: PsiTest() {
         fun `if an interface already implemented`() {
             cls.implementsInterfaces() shouldBe false
             execute {
-                cls.implementInterface(runnable)
+                cls.implement(runnable)
             }
 
             assertDoesNotThrow {
                 execute {
-                    cls.implementInterface(runnable)
+                    cls.implement(runnable)
                 }
             }
 
@@ -190,12 +190,12 @@ internal class PsiClassExtsSpec: PsiTest() {
         fun `if another interface is already implemented`() {
             cls.implementsInterfaces() shouldBe false
             execute {
-                cls.implementInterface(runnable)
+                cls.implement(runnable)
             }
 
             assertDoesNotThrow {
                 execute {
-                    cls.implementInterface(function)
+                    cls.implement(function)
                 }
             }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.217")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.218")


### PR DESCRIPTION
This PR adds extension functions for `PsiClass` that allow to make a class implement certain interface and test if it already implements this or other interfaces.

## Functions extending `PsiClass`
 * `implementsInterfaces()` — does the class implement any interface?
 * `implements(PsiJavaCodeReferenceElement)` — does it implement this interface?
 * `implement(PsiJavaCodeReferenceElement` — make this class implement this interface.

## Other notable changes
 * The function `PsiClass.addSuperclass` was deprecated in favour or the new function called `setSuperclass`. The previous name was somewhat misleading because (thankfully) Java does not have multiple inheritance of classes.
 * Added `@JvmName` for several extension functions.
 * Annotated several extensions of `PsiModifierListOwner` with `@CanIgnoreReturnValue` where appropriate.

