### PR TITLE
Bump Logging and trim `psi-java-bundle`

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -146,11 +146,13 @@
     <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ComparatorNotSerializable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CompareToUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConditionSignal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="false" />
     </inspection_tool>
     <inspection_tool class="ConfusingFloatingPointLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ConfusingMainMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingOctalEscape" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantConditions" enabled="true" level="TYPO" enabled_by_default="true">
@@ -192,6 +194,7 @@
       <option name="ignoreLocalVariables" value="false" />
       <option name="ignorePrivateMethodsAndFields" value="false" />
     </inspection_tool>
+    <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DisjointPackage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DollarSignInName" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -575,6 +578,7 @@
     </inspection_tool>
     <inspection_tool class="NonSerializableObjectBoundToHttpSession" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableObjectPassedToObjectStream" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableWithSerializationMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonShortCircuitBoolean" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonStaticFinalLogger" enabled="true" level="WARNING" enabled_by_default="true">
@@ -619,9 +623,6 @@
     </inspection_tool>
     <inspection_tool class="OctalAndDecimalIntegersMixed" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="OnDemandImport" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="OptionalOfNullableMisuse" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Production" level="WARNING" enabled="true" />
-    </inspection_tool>
     <inspection_tool class="OverloadedMethodsWithSameNumberOfParameters" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInconvertibleTypes" value="true" />
     </inspection_tool>
@@ -689,6 +690,7 @@
       <option name="ignoreSerializable" value="false" />
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
+    <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -709,6 +711,7 @@
     <inspection_tool class="SamePackageImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SameParameterValue" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreAnonymousInnerClasses" value="false" />
@@ -747,10 +750,13 @@
     <inspection_tool class="StringBufferToStringInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInMessageFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="StringEqualsEmptyString" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringReplaceableByStringBuffer" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="onlyWarnOnLoop" value="true" />
     </inspection_tool>
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -784,6 +790,7 @@
     <inspection_tool class="ThrowableNotThrown" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
+    <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThrownExceptionsPerMethod" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_limit" value="3" />
     </inspection_tool>
@@ -804,6 +811,7 @@
     <inspection_tool class="TransientFieldInNonSerializableClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TransientFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TrivialIf" enabled="true" level="TYPO" enabled_by_default="true" />
+    <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeMayBeWeakened" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Problems" level="INFO" enabled="true">

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -3,7 +3,11 @@
   <component name="Kotlin2JvmCompilerArguments">
     <option name="jvmTarget" value="11" />
   </component>
+  <component name="KotlinCommonCompilerArguments">
+    <option name="apiVersion" value="1.9.22" />
+    <option name="languageVersion" value="1.9.22" />
+  </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.22" />
+    <option name="version" value="1.9.22" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,6 @@ buildscript {
                 force(
                     io.spine.internal.dependency.Spine.base,
                     io.spine.internal.dependency.Spine.reflect,
-                    io.spine.internal.dependency.Spine.Logging.floggerApi,
                     io.spine.internal.dependency.Validation.java,
                     io.spine.internal.dependency.Protobuf.GradlePlugin.lib,
                     io.spine.internal.dependency.Kotlin.stdLibJdk8

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -31,23 +31,17 @@ import io.spine.internal.dependency.GradleDoctor
 import io.spine.internal.dependency.Kotest
 import io.spine.internal.dependency.Kover
 import io.spine.internal.dependency.Ksp
+import io.spine.internal.dependency.McJava
 import io.spine.internal.dependency.ProtoData
 import io.spine.internal.dependency.ProtoTap
 import io.spine.internal.dependency.Protobuf
-import io.spine.internal.dependency.Spine
 import io.spine.internal.gradle.standardToSpineSdk
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.tasks.JavaExec
 import org.gradle.kotlin.dsl.ScriptHandlerScope
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
-
-/**
- * Applies [standard][standardToSpineSdk] repositories to this `buildscript`.
- */
-fun ScriptHandlerScope.standardSpineSdkRepositories() {
-    repositories.standardToSpineSdk()
-}
 
 /**
  * Provides shortcuts to reference our dependency objects.
@@ -63,28 +57,47 @@ fun ScriptHandlerScope.standardSpineSdkRepositories() {
  *     get() = id(GradleDoctor.pluginId).version(GradleDoctor.version)
  * ```
  *
- * But for some plugins, it's impossible to apply them directly to a project.
+ * But for some plugins, it is impossible to apply them directly to a project.
  * For example, when a plugin is not published to Gradle Portal, it can only be
- * applied with the buildscript's classpath. Thus, it's needed to leave some freedom
+ * applied with the buildscript's classpath. Thus, it is necessary to leave some freedom
  * upon how to apply them. In such cases, just a shortcut to a dependency object
  * can be declared without applying the plugin in-place.
  */
 private const val ABOUT_DEPENDENCY_EXTENSIONS = ""
 
 /**
- * Shortcut to [Spine.McJava] dependency object.
+ * Applies [standard][standardToSpineSdk] repositories to this `buildscript`.
+ */
+fun ScriptHandlerScope.standardSpineSdkRepositories() {
+    repositories.standardToSpineSdk()
+}
+
+/**
+ * Shortcut to [McJava] dependency object for using under `buildScript`.
+ */
+val ScriptHandlerScope.mcJava: McJava
+    get() = McJava
+
+/**
+ * Shortcut to [McJava] dependency object.
  *
  * This plugin is not published to Gradle Portal and cannot be applied directly to a project.
  * Firstly, it should be put to buildscript's classpath and then applied by ID only.
  */
-val PluginDependenciesSpec.mcJava: Spine.McJava
-    get() = Spine.McJava
+val PluginDependenciesSpec.mcJava: McJava
+    get() = McJava
+
+/**
+ * Shortcut to [ProtoData] dependency object for using under `buildscript`.
+ */
+val ScriptHandlerScope.protoData: ProtoData
+    get() = ProtoData
 
 /**
  * Shortcut to [ProtoData] dependency object.
  *
- * This plugin is published at Gradle Portal. But when used in a pair with [mcJava],
- * it cannot be applied directly to a project.
+ * This plugin is published at Gradle Plugin Portal.
+ * But when used in a pair with [mcJava], it cannot be applied directly to a project.
  * It is so, because [mcJava] uses [protoData] as its dependency.
  * And buildscript's classpath ends up with both of them.
  */
@@ -187,10 +200,48 @@ fun Project.configureTaskDependencies() {
 }
 
 /**
- * Obtains all modules of the root project to which this project belongs that
- * do not have `"-tests"` in their names.
+ * Obtains all modules names of which do not have `"-tests"` as the suffix.
  *
- * By convention such modules are for integration tests and should be treated differently.
+ * By convention, such modules are for integration tests and should be treated differently.
  */
 val Project.productionModules: Iterable<Project>
     get() = rootProject.subprojects.filter { !it.name.contains("-tests") }
+
+
+/**
+ * Sets the remote debug option for this task.
+ *
+ * The port number is [5566][BuildSettings.REMOTE_DEBUG_PORT].
+ *
+ * @param enabled If `true` the task will be suspended.
+ */
+fun Task.remoteDebug(enabled: Boolean = true) { this as JavaExec
+    debugOptions {
+        this@debugOptions.enabled.set(enabled)
+        port.set(BuildSettings.REMOTE_DEBUG_PORT)
+        server.set(true)
+        suspend.set(true)
+    }
+}
+
+/**
+ * Sets remote debug options for the `launchProtoData` task.
+ *
+ * @param enabled if `true` the task will be suspended.
+ *
+ * @see remoteDebug
+ */
+fun Project.protoDataRemoteDebug(enabled: Boolean = true) {
+    tasks.findByName("launchProtoData")?.remoteDebug(enabled)
+}
+
+/**
+ * Sets remote debug options for the `launchTestProtoData` task.
+ *
+ * @param enabled if `true` the task will be suspended.
+ *
+ * @see remoteDebug
+ */
+fun Project.testProtoDataRemoteDebug(enabled: Boolean = true) {
+    tasks.findByName("launchTestProtoData")?.remoteDebug(enabled)
+}

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -50,11 +50,15 @@ import io.spine.internal.dependency.OpenTest4J
 import io.spine.internal.dependency.Plexus
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Slf4J
+import io.spine.internal.dependency.Spine
 import io.spine.internal.dependency.Truth
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ResolutionStrategy
+import org.gradle.kotlin.dsl.exclude
 
 /**
  * The function to be used in `buildscript` when a fully qualified call must be made.
@@ -165,4 +169,38 @@ fun NamedDomainObjectContainer<Configuration>.excludeProtobufLite() {
 
     excludeProtoLite("runtimeOnly")
     excludeProtoLite("testRuntimeOnly")
+}
+
+/**
+ * Excludes `spine-base` from the dependencies.
+ */
+@Suppress("unused")
+fun ModuleDependency.excludeSpineBase() {
+    exclude(group = Spine.group, module = "spine-base")
+}
+
+/**
+ * Forces the version of [Spine.base] in the given project.
+ */
+@Suppress("unused")
+fun Project.forceSpineBase() {
+    configurations.all {
+        resolutionStrategy {
+            force(Spine.base)
+        }
+    }
+}
+
+/**
+ * Forces configurations containing `"proto"` in their names (disregarding the case) to
+ * use [Spine.baseForBuildScript].
+ */
+fun Project.forceBaseInProtoTasks() {
+    configurations.configureEach {
+        if (name.toLowerCase().contains("proto")) {
+            resolutionStrategy {
+                force(Spine.baseForBuildScript)
+            }
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GradleDoctor.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GradleDoctor.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -33,6 +33,6 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object GradleDoctor {
-    const val version = "0.8.1"
+    const val version = "0.10.0"
     const val pluginId = "com.osacky.doctor"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
@@ -24,14 +24,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.gradle.jvm.toolchain.JavaLanguageVersion
+package io.spine.internal.dependency
 
 /**
- * This object provides high-level constants, like the version of JVM, to be used
- * throughout the project.
+ * Dependencies on Spine Model Compiler for Java.
+ *
+ * See [mc-java](https://github.com/SpineEventEngine/mc-java).
  */
-object BuildSettings {
-    private const val JVM_VERSION = 11
-    val javaVersion: JavaLanguageVersion = JavaLanguageVersion.of(JVM_VERSION)
-    const val REMOTE_DEBUG_PORT = 5566
+@Suppress(
+    "MemberVisibilityCanBePrivate" /* `pluginLib()` is used by subprojects. */,
+    "ConstPropertyName"
+)
+object McJava {
+    const val group = Spine.toolsGroup
+
+    /** The version used to in the build classpath. */
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.242"
+
+    /** The version to be used for integration tests. */
+    const val version = "2.0.0-SNAPSHOT.243"
+
+    const val pluginId = "io.spine.mc-java"
+
+    val pluginLib = pluginLib(dogfoodingVersion)
+    fun pluginLib(version: String): String = "$group:spine-mc-java-plugins:$version:all"
+
+    /** The artifact reference for forcing in configurations. */
+    @Suppress("unused")
+    const val pluginsArtifact: String = "$group:spine-mc-java-plugins:$version"
+
+    val base = base(version)
+    fun base(version: String): String = "$group:spine-mc-java-base:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -58,14 +58,22 @@ package io.spine.internal.dependency
     "KDocUnresolvedReference" /* Referencing private properties in constructor KDoc. */
 )
 object ProtoData {
+    const val pluginGroup = Spine.group
     const val group = "io.spine.protodata"
     const val pluginId = "io.spine.protodata"
+
+    /**
+     * Identifies ProtoData as a `classpath` dependency under `buildScript` block.
+     *
+     * The dependency is obtained from https://plugins.gradle.org/m2/.
+     */
+    const val module = "io.spine:protodata"
 
     /**
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.61.3"
+    private const val fallbackVersion = "0.61.4"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,14 +82,19 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.61.3"
+    private const val fallbackDfVersion = "0.61.4"
 
     /**
      * The artifact for the ProtoData Gradle plugin.
      */
     val pluginLib: String
 
-    fun pluginLib(version: String): String =
+    /**
+     * The artifact to be used during experiments when publishing locally.
+     *
+     * @see ProtoData
+     */
+    private fun pluginLib(version: String): String =
         "$group:gradle-plugin:$version"
 
     fun api(version: String): String =
@@ -89,10 +102,6 @@ object ProtoData {
 
     val api
         get() = api(version)
-
-    @Deprecated("Use `backend` instead", ReplaceWith("backend"))
-    val compiler
-        get() = backend
 
     val backend
         get() = "$group:protodata-backend:$version"
@@ -106,16 +115,8 @@ object ProtoData {
     val cliApi
         get() = "$group:protodata-cli-api:$version"
 
-    @Deprecated("Use `java()` instead", ReplaceWith("java(version)"))
-    fun codegenJava(version: String): String =
-        java(version)
-
     fun java(version: String): String =
         "$group:protodata-java:$version"
-
-    @Deprecated("Use `java` instead.", ReplaceWith("java"))
-    val codegenJava
-        get() = java(version)
 
     val java
         get() = java(version)
@@ -167,7 +168,7 @@ object ProtoData {
         } else {
             version = fallbackVersion
             dogfoodingVersion = fallbackDfVersion
-            pluginLib = "${Spine.group}:protodata:$version"
+            pluginLib = "$pluginGroup:protodata:$version"
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -33,7 +33,7 @@ object Roaster {
     /**
      * This is the last version build with Java 11.
      *
-     * Starting from version
+     * Starting from the version
      * [2.29.0.Final](https://github.com/forge/roaster/releases/tag/2.29.0.Final),
      * Roaster requires Java 17.
      */

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,21 +45,22 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.212"
+        const val base = "2.0.0-SNAPSHOT.215"
+        const val baseForBuildScript = "2.0.0-SNAPSHOT.215"
 
         /**
          * The version of [Spine.reflect].
          *
          * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
          */
-        const val reflect = "2.0.0-SNAPSHOT.188"
+        const val reflect = "2.0.0-SNAPSHOT.190"
 
         /**
          * The version of [Spine.Logging].
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.233"
+        const val logging = "2.0.0-SNAPSHOT.240"
 
         /**
          * The version of [Spine.testlib].
@@ -83,13 +84,6 @@ object Spine {
          * @see <a href="https://github.com/SpineEventEngine/model-compiler">spine-model-compiler</a>
          */
         const val mc = "2.0.0-SNAPSHOT.133"
-
-        /**
-         * The version of [McJava].
-         *
-         * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
-         */
-        const val mcJava = "2.0.0-SNAPSHOT.241"
 
         /**
          * The version of [Spine.baseTypes].
@@ -124,10 +118,10 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.223"
+        const val toolBase = "2.0.0-SNAPSHOT.226"
 
         /**
-         * The version of [Spine.javadocTools].
+         * The version of [Spine.javadocFilter].
          *
          * @see <a href="https://github.com/SpineEventEngine/doc-tools">spine-javadoc-tools</a>
          */
@@ -135,6 +129,7 @@ object Spine {
     }
 
     const val base = "$group:spine-base:${ArtifactVersion.base}"
+    const val baseForBuildScript = "$group:spine-base:${ArtifactVersion.baseForBuildScript}"
 
     const val reflect = "$group:spine-reflect:${ArtifactVersion.reflect}"
     const val baseTypes = "$group:spine-base-types:${ArtifactVersion.baseTypes}"
@@ -151,6 +146,9 @@ object Spine {
     const val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${ArtifactVersion.toolBase}"
     const val modelCompiler = "$toolsGroup:spine-model-compiler:${ArtifactVersion.mc}"
 
+    @Deprecated(message = "Please use top level `McJava` object instead.")
+    val McJava = io.spine.internal.dependency.McJava
+
     /**
      * Dependencies on the artifacts of the Spine Logging library.
      *
@@ -159,6 +157,7 @@ object Spine {
     object Logging {
         const val version = ArtifactVersion.logging
         const val lib = "$group:spine-logging:$version"
+        const val libJvm = "$group:spine-logging-jvm:$version"
 
         const val log4j2Backend = "$group:spine-logging-log4j2-backend:$version"
         const val stdContext = "$group:spine-logging-std-context:$version"
@@ -171,35 +170,8 @@ object Spine {
         internal const val middleware = "$group:spine-logging-middleware:$version"
         internal const val platformGenerator = "$group:spine-logging-platform-generator:$version"
         internal const val jvmDefaultPlatform = "$group:spine-logging-jvm-default-platform:$version"
-
-        @Deprecated(
-            message = "Please use `Logging.lib` instead.",
-            replaceWith = ReplaceWith("lib")
-        )
-        const val floggerApi = "$group:spine-flogger-api:$version"
-
-        @Deprecated(
-            message = "Please use `grpcContext` instead.",
-            replaceWith = ReplaceWith("grpcContext")
-        )
-        const val floggerGrpcContext = "$group:spine-flogger-grpc-context:$version"
     }
 
-    /**
-     * Dependencies on Spine Model Compiler for Java.
-     *
-     * See [mc-java](https://github.com/SpineEventEngine/mc-java).
-     */
-    @Suppress("MemberVisibilityCanBePrivate") // `pluginLib()` is used by subprojects.
-    object McJava {
-        const val version = ArtifactVersion.mcJava
-        const val pluginId = "io.spine.mc-java"
-        val pluginLib = pluginLib(version)
-        fun pluginLib(version: String): String = "$toolsGroup:spine-mc-java-plugins:$version:all"
-    }
-
-    @Deprecated("Please use `javadocFilter` instead.", ReplaceWith("javadocFilter"))
-    const val javadocTools = "$toolsGroup::${ArtifactVersion.javadocTools}"
     const val javadocFilter = "$toolsGroup:spine-javadoc-filter:${ArtifactVersion.javadocTools}"
 
     const val client = CoreJava.client // Added for brevity.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -166,10 +166,10 @@ object Spine {
 
         // Transitive dependencies.
         // Make `public` and use them to force a version in a particular repository, if needed.
-        internal const val julBackend = "$group:spine-logging-jul-backend:$version"
-        internal const val middleware = "$group:spine-logging-middleware:$version"
-        internal const val platformGenerator = "$group:spine-logging-platform-generator:$version"
-        internal const val jvmDefaultPlatform = "$group:spine-logging-jvm-default-platform:$version"
+        const val julBackend = "$group:spine-logging-jul-backend:$version"
+        const val middleware = "$group:spine-logging-middleware:$version"
+        const val platformGenerator = "$group:spine-logging-platform-generator:$version"
+        const val jvmDefaultPlatform = "$group:spine-logging-jvm-default-platform:$version"
     }
 
     const val javadocFilter = "$toolsGroup:spine-javadoc-filter:${ArtifactVersion.javadocTools}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.154"
+    const val version = "2.0.0-SNAPSHOT.160"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/TaskContainerExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/TaskContainerExtensions.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/MarkdownReportRenderer.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/MarkdownReportRenderer.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -54,9 +54,8 @@ internal class MarkdownReportRenderer(
     }
 
     private fun outputFile(project: Project): File {
-        val config =
-            project.extensions.findByName("licenseReport") as LicenseReportExtension
-        return File(config.outputDir).resolve(filename)
+        val ext = project.extensions.findByName("licenseReport") as LicenseReportExtension
+        return File(ext.outputDir).resolve(filename)
     }
 }
 

--- a/buildSrc/src/main/kotlin/jacoco-kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/jacoco-kotlin-jvm.gradle.kts
@@ -25,11 +25,6 @@
  */
 
 import io.spine.internal.gradle.buildDirectory
-import java.io.File
-import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.getting
-import org.gradle.kotlin.dsl.jacoco
-import org.gradle.testing.jacoco.tasks.JacocoReport
 
 plugins {
     jacoco

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -120,6 +120,7 @@ fun Module.forceConfigurations() {
                     JUnit.runner,
                     Spine.base,
                     Spine.Logging.lib,
+                    Spine.Logging.libJvm,
                     Spine.reflect,
                     Validation.runtime,
                     Grpc.stub,

--- a/dependencies.md
+++ b/dependencies.md
@@ -15,10 +15,6 @@
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -511,17 +507,17 @@
      * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
      * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
 1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
      * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
@@ -752,7 +748,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 20:35:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 21:47:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -774,10 +770,6 @@ This report was generated on **Thu Oct 24 20:35:41 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
@@ -1383,17 +1375,17 @@ This report was generated on **Thu Oct 24 20:35:41 WEST 2024** using [Gradle-Lic
      * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
      * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
 1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
      * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
@@ -1624,7 +1616,7 @@ This report was generated on **Thu Oct 24 20:35:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 21:47:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1654,10 +1646,6 @@ This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -1715,10 +1703,6 @@ This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-Lic
 1.  **Group** : io.netty. **Name** : netty-common. **Version** : 4.1.72.Final.
      * **Project URL:** [https://netty.io/](https://netty.io/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
-     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
-     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
 
 1.  **Group** : net.jcip. **Name** : jcip-annotations. **Version** : 1.0.
      * **Project URL:** [http://jcip.net/](http://jcip.net/)
@@ -2331,17 +2315,17 @@ This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-Lic
      * **Project URL:** [http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/](http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/)
      * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
 1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
      * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
@@ -2639,7 +2623,7 @@ This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 21:47:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2715,10 +2699,6 @@ This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-Lic
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3934,17 +3914,17 @@ This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-Lic
      * **Project URL:** [http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/](http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/)
      * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
 1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
      * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
@@ -4328,7 +4308,7 @@ This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 20:35:43 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 21:47:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4402,10 +4382,6 @@ This report was generated on **Thu Oct 24 20:35:43 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -5570,17 +5546,17 @@ This report was generated on **Thu Oct 24 20:35:43 WEST 2024** using [Gradle-Lic
      * **Project URL:** [http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/](http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/)
      * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
 1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
      * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
@@ -5952,7 +5928,7 @@ This report was generated on **Thu Oct 24 20:35:43 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 21:47:25 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6412,17 +6388,17 @@ This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-Lic
      * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
      * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
 1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
      * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
@@ -6653,7 +6629,7 @@ This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 21:47:25 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6671,10 +6647,6 @@ This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -7218,17 +7190,17 @@ This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-Lic
      * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
      * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.12.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
 
 1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
      * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
@@ -7459,4 +7431,4 @@ This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 21:47:25 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.227`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -13,6 +13,10 @@
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -70,10 +74,6 @@
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -752,12 +752,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:46:39 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 20:35:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.227`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -774,6 +774,10 @@ This report was generated on **Mon Oct 07 19:46:39 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
@@ -1620,12 +1624,12 @@ This report was generated on **Mon Oct 07 19:46:39 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.227`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -1650,6 +1654,10 @@ This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -1707,6 +1715,10 @@ This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-Lic
 1.  **Group** : io.netty. **Name** : netty-common. **Version** : 4.1.72.Final.
      * **Project URL:** [https://netty.io/](https://netty.io/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
 
 1.  **Group** : net.jcip. **Name** : jcip-annotations. **Version** : 1.0.
      * **Project URL:** [http://jcip.net/](http://jcip.net/)
@@ -1811,10 +1823,6 @@ This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2631,12 +2639,12 @@ This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 20:35:42 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.227`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2705,1697 +2713,12 @@ This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
-     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
-     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.ibm.icu. **Name** : icu4j. **Version** : 67.1.
-     * **Project URL:** [http://icu-project.org/](http://icu-project.org/)
-     * **License:** [Unicode/ICU License](https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE)
-
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-compiler. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-memory-agent. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-gui-forms-rt. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-jshell-protocol. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources-en. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-rt. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-structure-view. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-uast. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp-base. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : bootstrap. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : concurrency. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-ui. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor-ex. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : execution. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : icons. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-util-io. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-serialization. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lvcs. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer-annotations. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : remote-core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : resources-en. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ex. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ui. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-zip. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : workspace-model-storage. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.regexp. **Name** : regexp. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.remoteDev. **Name** : remote-dev-util. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-dom. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-structure-view. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.rd. **Name** : rd-core. **Version** : 2021.3.5.
-     * **Project URL:** [https://github.com/JetBrains/rd](https://github.com/JetBrains/rd)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : com.jgoodies. **Name** : forms. **Version** : 1.1-preview.
-     * **Project URL:** [http://www.jgoodies.com/](http://www.jgoodies.com/)
-     * **License:** BSD
-
-1.  **Group** : com.jgoodies. **Name** : jgoodies-common. **Version** : 1.4.0.
-     * **Project URL:** [http://www.jgoodies.com/downloads/libraries.html](http://www.jgoodies.com/downloads/libraries.html)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.html)
-
-1.  **Group** : com.miglayout. **Name** : miglayout-core. **Version** : 11.0.
-     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
-
-1.  **Group** : com.miglayout. **Name** : miglayout-swing. **Version** : 11.0.
-     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
-
-1.  **Group** : com.sun.activation. **Name** : javax.activation. **Version** : 1.2.0.
-     * **Project URL:** [http://www.oracle.com](http://www.oracle.com)
-     * **License:** [CDDL/GPLv2+CE](https://github.com/javaee/activation/blob/master/LICENSE.txt)
-
-1.  **Group** : com.sun.istack. **Name** : istack-commons-runtime. **Version** : 3.0.7.
-     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
-     * **License:** [CDDL 1.1](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
-     * **License:** [GPL2 w/ CPE](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : com.sun.xml.fastinfoset. **Name** : FastInfoset. **Version** : 1.2.15.
-     * **Project URL:** [http://fi.java.net](http://fi.java.net)
-     * **License:** [Apache License, Version 2.0](http://www.opensource.org/licenses/apache2.0.php)
-
-1.  **Group** : com.thoughtworks.xstream. **Name** : xstream. **Version** : 1.4.18.
-     * **Project URL:** [http://x-stream.github.io](http://x-stream.github.io)
-     * **License:** [BSD-3-Clause](http://x-stream.github.io/license.html)
-
-1.  **Group** : com.twelvemonkeys.common. **Name** : common-image. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.common. **Name** : common-io. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.common. **Name** : common-lang. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-core. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-metadata. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-tiff. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : commons-codec. **Name** : commons-codec. **Version** : 1.16.0.
-     * **Project URL:** [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-collections. **Name** : commons-collections. **Version** : 3.2.2.
-     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-io. **Name** : commons-io. **Version** : 2.11.0.
-     * **Project URL:** [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-lang. **Name** : commons-lang. **Version** : 2.4.
-     * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-logging. **Name** : commons-logging. **Version** : 1.2.
-     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
-     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
-     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : io.github.classgraph. **Name** : classgraph. **Version** : 4.8.128.
-     * **Project URL:** [https://github.com/classgraph/classgraph](https://github.com/classgraph/classgraph)
-     * **License:** [The MIT License (MIT)](http://opensource.org/licenses/MIT)
-
-1.  **Group** : io.github.x-stream. **Name** : mxparser. **Version** : 1.2.2.
-     * **Project URL:** [http://x-stream.github.io/mxparser](http://x-stream.github.io/mxparser)
-     * **License:** [Indiana University Extreme! Lab Software License](https://raw.githubusercontent.com/x-stream/mxparser/master/LICENSE.txt)
-
-1.  **Group** : io.netty. **Name** : netty-buffer. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec-http. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec-http2. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec-socks. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-common. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-handler. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-handler-proxy. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-resolver. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-transport. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
-     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
-     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
-
-1.  **Group** : javax.xml.bind. **Name** : jaxb-api. **Version** : 2.3.1.
-     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
-     * **License:** [CDDL 1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
-     * **License:** [GPL2 w/ CPE](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
-
-1.  **Group** : jaxen. **Name** : jaxen. **Version** : 1.2.0.
-     * **Project URL:** [http://www.cafeconleche.org/jaxen](http://www.cafeconleche.org/jaxen)
-     * **License:** [BSD License 2.0](https://raw.githubusercontent.com/jaxen-xpath/jaxen/master/LICENSE.txt)
-
-1.  **Group** : net.bytebuddy. **Name** : byte-buddy-agent. **Version** : 1.10.1.
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : net.jcip. **Name** : jcip-annotations. **Version** : 1.0.
-     * **Project URL:** [http://jcip.net/](http://jcip.net/)
-
-1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
-     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
-     * **License:** [Apache License, Version 2.0](${license.url})
-
-1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
-     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : fluent-hc. **Version** : 4.5.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : httpclient. **Version** : 4.5.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : httpcore. **Version** : 4.4.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : httpmime. **Version** : 4.5.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.velocity. **Name** : velocity. **Version** : 1.7.
-     * **Project URL:** [http://velocity.apache.org/engine/devel/](http://velocity.apache.org/engine/devel/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.xmlgraphics. **Name** : xmlgraphics-commons. **Version** : 2.6.
-     * **Project URL:** [http://xmlgraphics.apache.org/commons/](http://xmlgraphics.apache.org/commons/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.bouncycastle. **Name** : bcpg-jdk15on. **Version** : 1.69.
-     * **Project URL:** [https://www.bouncycastle.org/java.html](https://www.bouncycastle.org/java.html)
-     * **License:** [Apache Software License, Version 1.1](https://www.apache.org/licenses/LICENSE-1.1)
-     * **License:** [Bouncy Castle Licence](https://www.bouncycastle.org/licence.html)
-
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
-     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
-     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : org.glassfish.jaxb. **Name** : jaxb-runtime. **Version** : 2.3.1.
-     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : org.glassfish.jaxb. **Name** : txw2. **Version** : 2.3.1.
-     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : org.imgscalr. **Name** : imgscalr-lib. **Version** : 4.2.
-     * **Project URL:** [http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/](http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/)
-     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
-     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
-     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : marketplace-zip-signer. **Version** : 0.1.3.
-     * **Project URL:** [https://github.com/JetBrains/marketplace-zip-signer](https://github.com/JetBrains/marketplace-zip-signer)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij. **Name** : blockmap. **Version** : 1.0.2.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : commons-imaging. **Version** : 1.0-RC-1.
-     * **Project URL:** [http://commons.apache.org/proper/commons-imaging/](http://commons.apache.org/proper/commons-imaging/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : debugger-memory-agent. **Version** : 1.0.35.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-agent. **Version** : 1.0.613.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-test-discovery-agent. **Version** : 1.0.613.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : ion-java. **Version** : 1.8.2-4.
-     * **Project URL:** [https://github.com/amzn/ion-java/](https://github.com/amzn/ion-java/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : java-compatibility. **Version** : 1.0.1.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : jb-jdi. **Version** : 2.16.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
-     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : sa-jdwp. **Version** : 1.20.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
-     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-anim. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-awt-util. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-bridge. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-codec. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-constants. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-css. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-dom. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-ext. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-gvt. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-parser. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svg-dom. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svggen. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-transcoder. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-util. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-xml. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.completion. **Name** : completion-ranking-java. **Version** : 0.3.7.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps.jcef. **Name** : jcef. **Version** : 89.0.12-g2b76680-chromium-89.0.4389.90-api-1.6.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
-
-1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
-
-1.  **Group** : org.jetbrains.jediterm. **Name** : jediterm-pty. **Version** : 2.64.1.
-     * **Project URL:** [https://github.com/JetBrains/jediterm](https://github.com/JetBrains/jediterm)
-     * **License:** [LGPL 3.0](https://www.gnu.org/licenses/lgpl.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.pty4j. **Name** : pty4j. **Version** : 0.12.6.
-     * **Project URL:** [https://github.com/JetBrains/pty4j](https://github.com/JetBrains/pty4j)
-     * **License:** [Eclipse Public License 1.0](https://opensource.org/licenses/eclipse-1.0.php)
-
-1.  **Group** : org.jetbrains.pty4j. **Name** : purejavacomm. **Version** : 0.0.11.1.**No license information found**
-1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.14.2.
-     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
-     * **License:** [The MIT License](https://jsoup.org/license)
-
-1.  **Group** : org.jvnet.staxex. **Name** : stax-ex. **Version** : 1.8.
-     * **Project URL:** [http://stax-ex.java.net/](http://stax-ex.java.net/)
-     * **License:** [
-                Dual license consisting of the CDDL v1.1 and GPL v2
-            ](https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : org.jvnet.winp. **Name** : winp. **Version** : 1.28.
-     * **License:** [MIT license](http://www.opensource.org/licenses/mit-license.php)
-     * **License:** [The MIT license](http://www.opensource.org/licenses/mit-license.php)
-
-1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
-     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.mozilla. **Name** : rhino-runtime. **Version** : 1.7.13.
-     * **Project URL:** [https://developer.mozilla.org/en/Rhino](https://developer.mozilla.org/en/Rhino)
-     * **License:** [Mozilla Public License, Version 2.0](http://www.mozilla.org/MPL/2.0/index.txt)
-
-1.  **Group** : org.objenesis. **Name** : objenesis. **Version** : 3.2.
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.6.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.swinglabs. **Name** : swingx-core. **Version** : 1.6.2-2.
-     * **License:** [Lesser General Public License (LGPL)](http://www.gnu.org/copyleft/lesser.html)
-
-1.  **Group** : org.tukaani. **Name** : xz. **Version** : 1.9.
-     * **Project URL:** [https://tukaani.org/xz/java.html](https://tukaani.org/xz/java.html)
-     * **License:** Public Domain
-
-1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
-1.  **Group** : xerces. **Name** : xercesImpl. **Version** : 2.12.1.
-     * **Project URL:** [https://xerces.apache.org/xerces2-j/](https://xerces.apache.org/xerces2-j/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : xml-apis. **Name** : xml-apis-ext. **Version** : 1.3.04.
-     * **Project URL:** [http://xml.apache.org/commons/components/external/](http://xml.apache.org/commons/components/external/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : xml-resolver. **Name** : xml-resolver. **Version** : 1.2.
-     * **Project URL:** [http://xml.apache.org/commons/components/resolver/](http://xml.apache.org/commons/components/resolver/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : xmlpull. **Name** : xmlpull. **Version** : 1.1.3.1.
-     * **Project URL:** [http://www.xmlpull.org](http://www.xmlpull.org)
-     * **License:** [Public Domain](http://www.xmlpull.org/v1/download/unpacked/LICENSE.txt)
-
-## Compile, tests, and tooling
-1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
-     * **Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
-     * **License:** Public Domain
-
-1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
-     * **Project URL:** [http://nanoxml.cyberelf.be/](http://nanoxml.cyberelf.be/)
-     * **License:** [The zlib/libpng License](http://www.opensource.org/licenses/zlib-license.html)
-
-1.  **Group** : cglib. **Name** : cglib-nodep. **Version** : 3.2.4.
-     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.48.
-     * **Project URL:** [http://beust.com/jcommander](http://beust.com/jcommander)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.82.
-     * **Project URL:** [https://jcommander.org](https://jcommander.org)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.esotericsoftware.kryo. **Name** : kryo. **Version** : 2.24.0.
-     * **Project URL:** [https://github.com/EsotericSoftware/kryo](https://github.com/EsotericSoftware/kryo)
-     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : com.esotericsoftware.minlog. **Name** : minlog. **Version** : 1.2.
-     * **Project URL:** [http://code.google.com/p/minlog/](http://code.google.com/p/minlog/)
-     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : com.fasterxml. **Name** : aalto-xml. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.jr. **Name** : jackson-jr-objects. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-jr](https://github.com/FasterXML/jackson-jr)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.5.1.
-     * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.4.
-     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
-     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.kevinstern. **Name** : software-and-algorithms. **Version** : 1.0.
-     * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
-     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
-
-1.  **Group** : com.github.spullara.cli-parser. **Name** : cli-parser. **Version** : 1.1.5.
-     * **Project URL:** [http://code.google.com/p/cli-parser/](http://code.google.com/p/cli-parser/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.2.
-     * **Project URL:** [https://github.com/google/auto/tree/main/common](https://github.com/google/auto/tree/main/common)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.1.1.
-     * **Project URL:** [https://github.com/google/auto/tree/main/service](https://github.com/google/auto/tree/main/service)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
-     * **Project URL:** [https://github.com/google/auto/tree/main/value](https://github.com/google/auto/tree/main/value)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
-     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
-     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_check_api](https://errorprone.info/error_prone_check_api)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_core](https://errorprone.info/error_prone_core)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
-     * **Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
-     * **License:** [GNU General Public License, version 2, with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
-
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
-     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
-     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
-     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
-     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
-     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 32.1.3-jre.
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.inject. **Name** : guice. **Version** : 5.1.0.
-     * **Project URL:** [https://github.com/google/guice](https://github.com/google/guice)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
-     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-gradle-plugin. **Version** : 0.9.4.
-     * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
-     * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.ibm.icu. **Name** : icu4j. **Version** : 67.1.
-     * **Project URL:** [http://icu-project.org/](http://icu-project.org/)
-     * **License:** [Unicode/ICU License](https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE)
-
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-compiler. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-memory-agent. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-gui-forms-rt. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-jshell-protocol. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources-en. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-rt. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-structure-view. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-uast. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp-base. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : bootstrap. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : concurrency. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-ui. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor-ex. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : execution. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : icons. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-util-io. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-serialization. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lvcs. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer-annotations. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : remote-core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : resources-en. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ex. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ui. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-zip. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : workspace-model-storage. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.regexp. **Name** : regexp. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.remoteDev. **Name** : remote-dev-util. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-dom. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-structure-view. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.rd. **Name** : rd-core. **Version** : 2021.3.5.
-     * **Project URL:** [https://github.com/JetBrains/rd](https://github.com/JetBrains/rd)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : com.jgoodies. **Name** : forms. **Version** : 1.1-preview.
-     * **Project URL:** [http://www.jgoodies.com/](http://www.jgoodies.com/)
-     * **License:** BSD
-
-1.  **Group** : com.jgoodies. **Name** : jgoodies-common. **Version** : 1.4.0.
-     * **Project URL:** [http://www.jgoodies.com/downloads/libraries.html](http://www.jgoodies.com/downloads/libraries.html)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.html)
-
-1.  **Group** : com.miglayout. **Name** : miglayout-core. **Version** : 11.0.
-     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
-
-1.  **Group** : com.miglayout. **Name** : miglayout-swing. **Version** : 11.0.
-     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
-
-1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
-     * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
-     * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
-
-1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
-     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
-     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
-
-1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
-     * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.sun.activation. **Name** : javax.activation. **Version** : 1.2.0.
-     * **Project URL:** [http://www.oracle.com](http://www.oracle.com)
-     * **License:** [CDDL/GPLv2+CE](https://github.com/javaee/activation/blob/master/LICENSE.txt)
-
-1.  **Group** : com.sun.istack. **Name** : istack-commons-runtime. **Version** : 3.0.7.
-     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
-     * **License:** [CDDL 1.1](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
-     * **License:** [GPL2 w/ CPE](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : com.sun.xml.fastinfoset. **Name** : FastInfoset. **Version** : 1.2.15.
-     * **Project URL:** [http://fi.java.net](http://fi.java.net)
-     * **License:** [Apache License, Version 2.0](http://www.opensource.org/licenses/apache2.0.php)
-
-1.  **Group** : com.thoughtworks.xstream. **Name** : xstream. **Version** : 1.4.18.
-     * **Project URL:** [http://x-stream.github.io](http://x-stream.github.io)
-     * **License:** [BSD-3-Clause](http://x-stream.github.io/license.html)
-
-1.  **Group** : com.twelvemonkeys.common. **Name** : common-image. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.common. **Name** : common-io. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.common. **Name** : common-lang. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-core. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-metadata. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-tiff. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
-     * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-codec. **Name** : commons-codec. **Version** : 1.16.0.
-     * **Project URL:** [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-collections. **Name** : commons-collections. **Version** : 3.2.2.
-     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-io. **Name** : commons-io. **Version** : 2.11.0.
-     * **Project URL:** [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-lang. **Name** : commons-lang. **Version** : 2.4.
-     * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-logging. **Name** : commons-logging. **Version** : 1.2.
-     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
-     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
-     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.7.4.
-     * **Project URL:** [https://picocli.info](https://picocli.info)
-     * **License:** [The Apache Software License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.classgraph. **Name** : classgraph. **Version** : 4.8.128.
-     * **Project URL:** [https://github.com/classgraph/classgraph](https://github.com/classgraph/classgraph)
-     * **License:** [The MIT License (MIT)](http://opensource.org/licenses/MIT)
-
-1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
-     * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k. **Version** : 0.4.0.
-     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k-jvm. **Version** : 0.4.0.
-     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.eisop. **Name** : dataflow-errorprone. **Version** : 3.34.0-eisop1.
-     * **Project URL:** [https://eisop.github.io/](https://eisop.github.io/)
-     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
-
-1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.12.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.x-stream. **Name** : mxparser. **Version** : 1.2.2.
-     * **Project URL:** [http://x-stream.github.io/mxparser](http://x-stream.github.io/mxparser)
-     * **License:** [Indiana University Extreme! Lab Software License](https://raw.githubusercontent.com/x-stream/mxparser/master/LICENSE.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-api. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-cli. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-core. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-metrics. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-parser. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-psi-utils. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-html. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-md. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-sarif. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-txt. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-xml. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-complexity. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-coroutines. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-documentation. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-empty. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-errorprone. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-exceptions. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-naming. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-performance. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-style. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-tooling. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-utils. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.kotest. **Name** : kotest-assertions-api. **Version** : 5.8.0.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-assertions-api-jvm. **Version** : 5.8.0.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-assertions-core. **Version** : 5.8.0.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-assertions-core-jvm. **Version** : 5.8.0.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-assertions-shared. **Version** : 5.8.0.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-assertions-shared-jvm. **Version** : 5.8.0.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-common. **Version** : 5.8.0.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.kotest. **Name** : kotest-common-jvm. **Version** : 5.8.0.
-     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
-     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-buffer. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec-http. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec-http2. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec-socks. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-common. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-handler. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-handler-proxy. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-resolver. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-transport. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : it.unimi.dsi. **Name** : fastutil-core. **Version** : 8.5.12.
-     * **Project URL:** [http://fastutil.di.unimi.it/](http://fastutil.di.unimi.it/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
-
-1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
-     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
-     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
-
-1.  **Group** : javax.inject. **Name** : javax.inject. **Version** : 1.
-     * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : javax.xml.bind. **Name** : jaxb-api. **Version** : 2.3.1.
-     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
-     * **License:** [CDDL 1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
-     * **License:** [GPL2 w/ CPE](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
-
-1.  **Group** : jaxen. **Name** : jaxen. **Version** : 1.2.0.
-     * **Project URL:** [http://www.cafeconleche.org/jaxen](http://www.cafeconleche.org/jaxen)
-     * **License:** [BSD License 2.0](https://raw.githubusercontent.com/jaxen-xpath/jaxen/master/LICENSE.txt)
-
-1.  **Group** : junit. **Name** : junit. **Version** : 4.13.1.
-     * **Project URL:** [http://junit.org](http://junit.org)
-     * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
-
-1.  **Group** : net.bytebuddy. **Name** : byte-buddy-agent. **Version** : 1.10.1.
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.6.0.
-     * **Project URL:** [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
-     * **License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
-
-1.  **Group** : net.jcip. **Name** : jcip-annotations. **Version** : 1.0.
-     * **Project URL:** [http://jcip.net/](http://jcip.net/)
-
-1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 12.2.
-     * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
-     * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
-
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.55.0.
-     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
-
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.55.0.
-     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
-
-1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
-     * **Project URL:** [http://saxon.sourceforge.net/](http://saxon.sourceforge.net/)
-     * **License:** [Mozilla Public License Version 1.0](http://www.mozilla.org/MPL/MPL-1.0.txt)
-
-1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
-     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
-     * **License:** [Apache License, Version 2.0](${license.url})
-
-1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.11.1.
-     * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
-     * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
-
-1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.7.2.
-     * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
-     * **License:** [The BSD License](http://www.antlr.org/license.html)
-
-1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
-     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.8.1.
-     * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : fluent-hc. **Version** : 4.5.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : httpclient. **Version** : 4.5.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : httpcore. **Version** : 4.4.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : httpmime. **Version** : 4.5.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents.client5. **Name** : httpclient5. **Version** : 5.1.3.
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5. **Version** : 5.1.3.
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5-h2. **Version** : 5.1.3.
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.velocity. **Name** : velocity. **Version** : 1.7.
-     * **Project URL:** [http://velocity.apache.org/engine/devel/](http://velocity.apache.org/engine/devel/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.xmlgraphics. **Name** : xmlgraphics-commons. **Version** : 2.6.
-     * **Project URL:** [http://xmlgraphics.apache.org/commons/](http://xmlgraphics.apache.org/commons/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
-     * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.bouncycastle. **Name** : bcpg-jdk15on. **Version** : 1.69.
-     * **Project URL:** [https://www.bouncycastle.org/java.html](https://www.bouncycastle.org/java.html)
-     * **License:** [Apache Software License, Version 1.1](https://www.apache.org/licenses/LICENSE-1.1)
-     * **License:** [Bouncy Castle Licence](https://www.bouncycastle.org/licence.html)
-
-1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
-     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
-     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
-     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
-     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
-     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
-     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.glassfish.jaxb. **Name** : jaxb-runtime. **Version** : 2.3.1.
-     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : org.glassfish.jaxb. **Name** : txw2. **Version** : 2.3.1.
-     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : org.hamcrest. **Name** : hamcrest. **Version** : 2.2.
-     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
-     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 2.2.
-     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
-     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : org.imgscalr. **Name** : imgscalr-lib. **Version** : 4.2.
-     * **Project URL:** [http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/](http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/)
-     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
-     * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
-     * **License:** [Apache License 2.0](http://www.apache.org/licenses/)
-     * **License:** [LGPL 2.1](http://www.gnu.org/licenses/lgpl-2.1.html)
-     * **License:** [MPL 1.1](http://www.mozilla.org/MPL/MPL-1.1.html)
-
-1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-api. **Version** : 2.28.0.Final.
-     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
-     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
-
-1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-jdt. **Version** : 2.28.0.Final.
-     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
-     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
-     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
-     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.5.2.
-     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.5.2.
-     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : marketplace-zip-signer. **Version** : 0.1.3.
-     * **Project URL:** [https://github.com/JetBrains/marketplace-zip-signer](https://github.com/JetBrains/marketplace-zip-signer)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : analysis-kotlin-descriptors. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : analysis-markdown. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : dokka-base. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij. **Name** : blockmap. **Version** : 1.0.2.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : commons-imaging. **Version** : 1.0-RC-1.
-     * **Project URL:** [http://commons.apache.org/proper/commons-imaging/](http://commons.apache.org/proper/commons-imaging/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : debugger-memory-agent. **Version** : 1.0.35.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-agent. **Version** : 1.0.613.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-test-discovery-agent. **Version** : 1.0.613.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : ion-java. **Version** : 1.8.2-4.
-     * **Project URL:** [https://github.com/amzn/ion-java/](https://github.com/amzn/ion-java/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : java-compatibility. **Version** : 1.0.1.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : jb-jdi. **Version** : 2.16.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
-     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : sa-jdwp. **Version** : 1.20.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
-     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-anim. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-awt-util. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-bridge. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-codec. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-constants. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-css. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-dom. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-ext. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-gvt. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-parser. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svg-dom. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svggen. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-transcoder. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-util. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-xml. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.completion. **Name** : completion-ranking-java. **Version** : 0.3.7.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps.jcef. **Name** : jcef. **Version** : 89.0.12-g2b76680-chromium-89.0.4389.90-api-1.6.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
-
-1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
-
-1.  **Group** : org.jetbrains.jediterm. **Name** : jediterm-pty. **Version** : 2.64.1.
-     * **Project URL:** [https://github.com/JetBrains/jediterm](https://github.com/JetBrains/jediterm)
-     * **License:** [LGPL 3.0](https://www.gnu.org/licenses/lgpl.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu. **Version** : 0.17.3.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.8.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.9.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.pty4j. **Name** : pty4j. **Version** : 0.12.6.
-     * **Project URL:** [https://github.com/JetBrains/pty4j](https://github.com/JetBrains/pty4j)
-     * **License:** [Eclipse Public License 1.0](https://opensource.org/licenses/eclipse-1.0.php)
-
-1.  **Group** : org.jetbrains.pty4j. **Name** : purejavacomm. **Version** : 0.0.11.1.**No license information found**
-1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.14.2.
-     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
-     * **License:** [The MIT License](https://jsoup.org/license)
-
-1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.16.1.
-     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
-     * **License:** [The MIT License](https://jsoup.org/license)
-
-1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.jvnet.staxex. **Name** : stax-ex. **Version** : 1.8.
-     * **Project URL:** [http://stax-ex.java.net/](http://stax-ex.java.net/)
-     * **License:** [
-                Dual license consisting of the CDDL v1.1 and GPL v2
-            ](https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : org.jvnet.winp. **Name** : winp. **Version** : 1.28.
-     * **License:** [MIT license](http://www.opensource.org/licenses/mit-license.php)
-     * **License:** [The MIT license](http://www.opensource.org/licenses/mit-license.php)
-
-1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
-     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.mozilla. **Name** : rhino-runtime. **Version** : 1.7.13.
-     * **Project URL:** [https://developer.mozilla.org/en/Rhino](https://developer.mozilla.org/en/Rhino)
-     * **License:** [Mozilla Public License, Version 2.0](http://www.mozilla.org/MPL/2.0/index.txt)
-
-1.  **Group** : org.objenesis. **Name** : objenesis. **Version** : 3.2.
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.6.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm-commons. **Version** : 9.6.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm-tree. **Version** : 9.6.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 3.1.4.
-     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
-     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
-
-1.  **Group** : org.reflections. **Name** : reflections. **Version** : 0.10.2.
-     * **Project URL:** [http://github.com/ronmamo/reflections](http://github.com/ronmamo/reflections)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [WTFPL](http://www.wtfpl.net/)
-
-1.  **Group** : org.snakeyaml. **Name** : snakeyaml-engine. **Version** : 2.6.
-     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.swinglabs. **Name** : swingx-core. **Version** : 1.6.2-2.
-     * **License:** [Lesser General Public License (LGPL)](http://www.gnu.org/copyleft/lesser.html)
-
-1.  **Group** : org.tukaani. **Name** : xz. **Version** : 1.9.
-     * **Project URL:** [https://tukaani.org/xz/java.html](https://tukaani.org/xz/java.html)
-     * **License:** Public Domain
-
-1.  **Group** : org.xmlresolver. **Name** : xmlresolver. **Version** : 5.1.2.
-     * **Project URL:** [https://github.com/xmlresolver/xmlresolver](https://github.com/xmlresolver/xmlresolver)
-     * **License:** [Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
-1.  **Group** : xerces. **Name** : xercesImpl. **Version** : 2.12.1.
-     * **Project URL:** [https://xerces.apache.org/xerces2-j/](https://xerces.apache.org/xerces2-j/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : xml-apis. **Name** : xml-apis-ext. **Version** : 1.3.04.
-     * **Project URL:** [http://xml.apache.org/commons/components/external/](http://xml.apache.org/commons/components/external/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : xml-resolver. **Name** : xml-resolver. **Version** : 1.2.
-     * **Project URL:** [http://xml.apache.org/commons/components/resolver/](http://xml.apache.org/commons/components/resolver/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : xmlpull. **Name** : xmlpull. **Version** : 1.1.3.1.
-     * **Project URL:** [http://www.xmlpull.org](http://www.xmlpull.org)
-     * **License:** [Public Domain](http://www.xmlpull.org/v1/download/unpacked/LICENSE.txt)
-
-
-The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
-
-This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
-
-
-
-
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.226`
-
-## Runtime
-1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
-     * **Project URL:** [http://nanoxml.cyberelf.be/](http://nanoxml.cyberelf.be/)
-     * **License:** [The zlib/libpng License](http://www.opensource.org/licenses/zlib-license.html)
-
-1.  **Group** : cglib. **Name** : cglib-nodep. **Version** : 3.2.4.
-     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.esotericsoftware.kryo. **Name** : kryo. **Version** : 2.24.0.
-     * **Project URL:** [https://github.com/EsotericSoftware/kryo](https://github.com/EsotericSoftware/kryo)
-     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : com.esotericsoftware.minlog. **Name** : minlog. **Version** : 1.2.
-     * **Project URL:** [http://code.google.com/p/minlog/](http://code.google.com/p/minlog/)
-     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : com.fasterxml. **Name** : aalto-xml. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.jr. **Name** : jackson-jr-objects. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-jr](https://github.com/FasterXML/jackson-jr)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.4.
-     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.spullara.cli-parser. **Name** : cli-parser. **Version** : 1.1.5.
-     * **Project URL:** [http://code.google.com/p/cli-parser/](http://code.google.com/p/cli-parser/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
-     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
-     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4807,10 +3130,6 @@ This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -4991,1060 +3310,6 @@ This report was generated on **Mon Oct 07 19:46:40 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.github.spullara.cli-parser. **Name** : cli-parser. **Version** : 1.1.5.
      * **Project URL:** [http://code.google.com/p/cli-parser/](http://code.google.com/p/cli-parser/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.2.
-     * **Project URL:** [https://github.com/google/auto/tree/main/common](https://github.com/google/auto/tree/main/common)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.1.1.
-     * **Project URL:** [https://github.com/google/auto/tree/main/service](https://github.com/google/auto/tree/main/service)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
-     * **Project URL:** [https://github.com/google/auto/tree/main/value](https://github.com/google/auto/tree/main/value)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
-     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
-     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_check_api](https://errorprone.info/error_prone_check_api)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_core](https://errorprone.info/error_prone_core)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
-     * **Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
-     * **License:** [GNU General Public License, version 2, with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
-
-1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
-     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 32.1.3-jre.
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.inject. **Name** : guice. **Version** : 5.1.0.
-     * **Project URL:** [https://github.com/google/guice](https://github.com/google/guice)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
-     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
-     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.ibm.icu. **Name** : icu4j. **Version** : 67.1.
-     * **Project URL:** [http://icu-project.org/](http://icu-project.org/)
-     * **License:** [Unicode/ICU License](https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE)
-
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-compiler. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-memory-agent. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-gui-forms-rt. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-jshell-protocol. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources-en. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-rt. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-structure-view. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.java. **Name** : java-uast. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp-base. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : bootstrap. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : concurrency. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-ui. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor-ex. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : execution. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : icons. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-util-io. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-serialization. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : lvcs. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer-annotations. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : remote-core. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : resources-en. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ex. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ui. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-zip. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.platform. **Name** : workspace-model-storage. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.regexp. **Name** : regexp. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.remoteDev. **Name** : remote-dev-util. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-analysis. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-dom. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi-impl. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-structure-view. **Version** : 213.7172.53.**No license information found**
-1.  **Group** : com.jetbrains.rd. **Name** : rd-core. **Version** : 2021.3.5.
-     * **Project URL:** [https://github.com/JetBrains/rd](https://github.com/JetBrains/rd)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : com.jgoodies. **Name** : forms. **Version** : 1.1-preview.
-     * **Project URL:** [http://www.jgoodies.com/](http://www.jgoodies.com/)
-     * **License:** BSD
-
-1.  **Group** : com.jgoodies. **Name** : jgoodies-common. **Version** : 1.4.0.
-     * **Project URL:** [http://www.jgoodies.com/downloads/libraries.html](http://www.jgoodies.com/downloads/libraries.html)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.html)
-
-1.  **Group** : com.miglayout. **Name** : miglayout-core. **Version** : 11.0.
-     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
-
-1.  **Group** : com.miglayout. **Name** : miglayout-swing. **Version** : 11.0.
-     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
-
-1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
-     * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
-     * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
-
-1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
-     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
-     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
-
-1.  **Group** : com.sun.activation. **Name** : javax.activation. **Version** : 1.2.0.
-     * **Project URL:** [http://www.oracle.com](http://www.oracle.com)
-     * **License:** [CDDL/GPLv2+CE](https://github.com/javaee/activation/blob/master/LICENSE.txt)
-
-1.  **Group** : com.sun.istack. **Name** : istack-commons-runtime. **Version** : 3.0.7.
-     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
-     * **License:** [CDDL 1.1](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
-     * **License:** [GPL2 w/ CPE](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : com.sun.xml.fastinfoset. **Name** : FastInfoset. **Version** : 1.2.15.
-     * **Project URL:** [http://fi.java.net](http://fi.java.net)
-     * **License:** [Apache License, Version 2.0](http://www.opensource.org/licenses/apache2.0.php)
-
-1.  **Group** : com.thoughtworks.xstream. **Name** : xstream. **Version** : 1.4.18.
-     * **Project URL:** [http://x-stream.github.io](http://x-stream.github.io)
-     * **License:** [BSD-3-Clause](http://x-stream.github.io/license.html)
-
-1.  **Group** : com.twelvemonkeys.common. **Name** : common-image. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.common. **Name** : common-io. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.common. **Name** : common-lang. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-core. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-metadata. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-tiff. **Version** : 3.6.1.
-     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
-
-1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
-     * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-codec. **Name** : commons-codec. **Version** : 1.16.0.
-     * **Project URL:** [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-collections. **Name** : commons-collections. **Version** : 3.2.2.
-     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-io. **Name** : commons-io. **Version** : 2.11.0.
-     * **Project URL:** [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-lang. **Name** : commons-lang. **Version** : 2.4.
-     * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : commons-logging. **Name** : commons-logging. **Version** : 1.2.
-     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
-     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
-     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.7.4.
-     * **Project URL:** [https://picocli.info](https://picocli.info)
-     * **License:** [The Apache Software License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.classgraph. **Name** : classgraph. **Version** : 4.8.128.
-     * **Project URL:** [https://github.com/classgraph/classgraph](https://github.com/classgraph/classgraph)
-     * **License:** [The MIT License (MIT)](http://opensource.org/licenses/MIT)
-
-1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
-     * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k. **Version** : 0.4.0.
-     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k-jvm. **Version** : 0.4.0.
-     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.eisop. **Name** : dataflow-errorprone. **Version** : 3.34.0-eisop1.
-     * **Project URL:** [https://eisop.github.io/](https://eisop.github.io/)
-     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
-
-1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.12.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.github.x-stream. **Name** : mxparser. **Version** : 1.2.2.
-     * **Project URL:** [http://x-stream.github.io/mxparser](http://x-stream.github.io/mxparser)
-     * **License:** [Indiana University Extreme! Lab Software License](https://raw.githubusercontent.com/x-stream/mxparser/master/LICENSE.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-api. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-cli. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-core. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-metrics. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-parser. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-psi-utils. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-html. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-md. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-sarif. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-txt. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-xml. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-complexity. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-coroutines. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-documentation. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-empty. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-errorprone. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-exceptions. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-naming. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-performance. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-style. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-tooling. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-utils. **Version** : 1.23.0.
-     * **Project URL:** [https://detekt.dev](https://detekt.dev)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : io.netty. **Name** : netty-buffer. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec-http. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec-http2. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-codec-socks. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-common. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-handler. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-handler-proxy. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-resolver. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : io.netty. **Name** : netty-transport. **Version** : 4.1.72.Final.
-     * **Project URL:** [https://netty.io/](https://netty.io/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : it.unimi.dsi. **Name** : fastutil-core. **Version** : 8.5.12.
-     * **Project URL:** [http://fastutil.di.unimi.it/](http://fastutil.di.unimi.it/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
-
-1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
-     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
-     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
-
-1.  **Group** : javax.inject. **Name** : javax.inject. **Version** : 1.
-     * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : javax.xml.bind. **Name** : jaxb-api. **Version** : 2.3.1.
-     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
-     * **License:** [CDDL 1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
-     * **License:** [GPL2 w/ CPE](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
-
-1.  **Group** : jaxen. **Name** : jaxen. **Version** : 1.2.0.
-     * **Project URL:** [http://www.cafeconleche.org/jaxen](http://www.cafeconleche.org/jaxen)
-     * **License:** [BSD License 2.0](https://raw.githubusercontent.com/jaxen-xpath/jaxen/master/LICENSE.txt)
-
-1.  **Group** : junit. **Name** : junit. **Version** : 4.13.1.
-     * **Project URL:** [http://junit.org](http://junit.org)
-     * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
-
-1.  **Group** : net.bytebuddy. **Name** : byte-buddy-agent. **Version** : 1.10.1.
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.6.0.
-     * **Project URL:** [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
-     * **License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
-
-1.  **Group** : net.jcip. **Name** : jcip-annotations. **Version** : 1.0.
-     * **Project URL:** [http://jcip.net/](http://jcip.net/)
-
-1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 12.2.
-     * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
-     * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
-
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.55.0.
-     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
-
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.55.0.
-     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
-
-1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
-     * **Project URL:** [http://saxon.sourceforge.net/](http://saxon.sourceforge.net/)
-     * **License:** [Mozilla Public License Version 1.0](http://www.mozilla.org/MPL/MPL-1.0.txt)
-
-1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
-     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
-     * **License:** [Apache License, Version 2.0](${license.url})
-
-1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.11.1.
-     * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
-     * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
-
-1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.7.2.
-     * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
-     * **License:** [The BSD License](http://www.antlr.org/license.html)
-
-1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
-     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.8.1.
-     * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : fluent-hc. **Version** : 4.5.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : httpclient. **Version** : 4.5.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : httpcore. **Version** : 4.4.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents. **Name** : httpmime. **Version** : 4.5.13.
-     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents.client5. **Name** : httpclient5. **Version** : 5.1.3.
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5. **Version** : 5.1.3.
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5-h2. **Version** : 5.1.3.
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.velocity. **Name** : velocity. **Version** : 1.7.
-     * **Project URL:** [http://velocity.apache.org/engine/devel/](http://velocity.apache.org/engine/devel/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apache.xmlgraphics. **Name** : xmlgraphics-commons. **Version** : 2.6.
-     * **Project URL:** [http://xmlgraphics.apache.org/commons/](http://xmlgraphics.apache.org/commons/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
-     * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.bouncycastle. **Name** : bcpg-jdk15on. **Version** : 1.69.
-     * **Project URL:** [https://www.bouncycastle.org/java.html](https://www.bouncycastle.org/java.html)
-     * **License:** [Apache Software License, Version 1.1](https://www.apache.org/licenses/LICENSE-1.1)
-     * **License:** [Bouncy Castle Licence](https://www.bouncycastle.org/licence.html)
-
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
-     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
-     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
-     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
-
-1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
-     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.glassfish.jaxb. **Name** : jaxb-runtime. **Version** : 2.3.1.
-     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : org.glassfish.jaxb. **Name** : txw2. **Version** : 2.3.1.
-     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : org.hamcrest. **Name** : hamcrest. **Version** : 2.2.
-     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
-     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 2.2.
-     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
-     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : org.imgscalr. **Name** : imgscalr-lib. **Version** : 4.2.
-     * **Project URL:** [http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/](http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/)
-     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
-     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
-
-1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
-     * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
-     * **License:** [Apache License 2.0](http://www.apache.org/licenses/)
-     * **License:** [LGPL 2.1](http://www.gnu.org/licenses/lgpl-2.1.html)
-     * **License:** [MPL 1.1](http://www.mozilla.org/MPL/MPL-1.1.html)
-
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
-     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
-     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.5.2.
-     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.5.2.
-     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains. **Name** : marketplace-zip-signer. **Version** : 0.1.3.
-     * **Project URL:** [https://github.com/JetBrains/marketplace-zip-signer](https://github.com/JetBrains/marketplace-zip-signer)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : analysis-kotlin-descriptors. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : analysis-markdown. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : dokka-base. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
-     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij. **Name** : blockmap. **Version** : 1.0.2.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : commons-imaging. **Version** : 1.0-RC-1.
-     * **Project URL:** [http://commons.apache.org/proper/commons-imaging/](http://commons.apache.org/proper/commons-imaging/)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : debugger-memory-agent. **Version** : 1.0.35.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-agent. **Version** : 1.0.613.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-test-discovery-agent. **Version** : 1.0.613.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : ion-java. **Version** : 1.8.2-4.
-     * **Project URL:** [https://github.com/amzn/ion-java/](https://github.com/amzn/ion-java/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : java-compatibility. **Version** : 1.0.1.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : jb-jdi. **Version** : 2.16.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
-     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : sa-jdwp. **Version** : 1.20.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
-     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-anim. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-awt-util. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-bridge. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-codec. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-constants. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-css. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-dom. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-ext. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-gvt. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-parser. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svg-dom. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svggen. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-transcoder. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-util. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-xml. **Version** : 1.14.0-24.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.intellij.deps.completion. **Name** : completion-ranking-java. **Version** : 0.3.7.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps.jcef. **Name** : jcef. **Version** : 89.0.12-g2b76680-chromium-89.0.4389.90-api-1.6.**No license information found**
-1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
-
-1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
-     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
-     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
-
-1.  **Group** : org.jetbrains.jediterm. **Name** : jediterm-pty. **Version** : 2.64.1.
-     * **Project URL:** [https://github.com/JetBrains/jediterm](https://github.com/JetBrains/jediterm)
-     * **License:** [LGPL 3.0](https://www.gnu.org/licenses/lgpl.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.8.22.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.6.4.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.8.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.9.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.4.1.
-     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.pty4j. **Name** : pty4j. **Version** : 0.12.6.
-     * **Project URL:** [https://github.com/JetBrains/pty4j](https://github.com/JetBrains/pty4j)
-     * **License:** [Eclipse Public License 1.0](https://opensource.org/licenses/eclipse-1.0.php)
-
-1.  **Group** : org.jetbrains.pty4j. **Name** : purejavacomm. **Version** : 0.0.11.1.**No license information found**
-1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.14.2.
-     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
-     * **License:** [The MIT License](https://jsoup.org/license)
-
-1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.16.1.
-     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
-     * **License:** [The MIT License](https://jsoup.org/license)
-
-1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.10.0.
-     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
-     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
-
-1.  **Group** : org.jvnet.staxex. **Name** : stax-ex. **Version** : 1.8.
-     * **Project URL:** [http://stax-ex.java.net/](http://stax-ex.java.net/)
-     * **License:** [
-                Dual license consisting of the CDDL v1.1 and GPL v2
-            ](https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html)
-
-1.  **Group** : org.jvnet.winp. **Name** : winp. **Version** : 1.28.
-     * **License:** [MIT license](http://www.opensource.org/licenses/mit-license.php)
-     * **License:** [The MIT license](http://www.opensource.org/licenses/mit-license.php)
-
-1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
-     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.mozilla. **Name** : rhino-runtime. **Version** : 1.7.13.
-     * **Project URL:** [https://developer.mozilla.org/en/Rhino](https://developer.mozilla.org/en/Rhino)
-     * **License:** [Mozilla Public License, Version 2.0](http://www.mozilla.org/MPL/2.0/index.txt)
-
-1.  **Group** : org.objenesis. **Name** : objenesis. **Version** : 3.2.
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
-     * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
-     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.6.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm-commons. **Version** : 9.6.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.ow2.asm. **Name** : asm-tree. **Version** : 9.6.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 3.1.4.
-     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
-     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
-
-1.  **Group** : org.reflections. **Name** : reflections. **Version** : 0.10.2.
-     * **Project URL:** [http://github.com/ronmamo/reflections](http://github.com/ronmamo/reflections)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [WTFPL](http://www.wtfpl.net/)
-
-1.  **Group** : org.snakeyaml. **Name** : snakeyaml-engine. **Version** : 2.6.
-     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.swinglabs. **Name** : swingx-core. **Version** : 1.6.2-2.
-     * **License:** [Lesser General Public License (LGPL)](http://www.gnu.org/copyleft/lesser.html)
-
-1.  **Group** : org.tukaani. **Name** : xz. **Version** : 1.9.
-     * **Project URL:** [https://tukaani.org/xz/java.html](https://tukaani.org/xz/java.html)
-     * **License:** Public Domain
-
-1.  **Group** : org.xmlresolver. **Name** : xmlresolver. **Version** : 5.1.2.
-     * **Project URL:** [https://github.com/xmlresolver/xmlresolver](https://github.com/xmlresolver/xmlresolver)
-     * **License:** [Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
-1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
-1.  **Group** : xerces. **Name** : xercesImpl. **Version** : 2.12.1.
-     * **Project URL:** [https://xerces.apache.org/xerces2-j/](https://xerces.apache.org/xerces2-j/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : xml-apis. **Name** : xml-apis-ext. **Version** : 1.3.04.
-     * **Project URL:** [http://xml.apache.org/commons/components/external/](http://xml.apache.org/commons/components/external/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : xml-resolver. **Name** : xml-resolver. **Version** : 1.2.
-     * **Project URL:** [http://xml.apache.org/commons/components/resolver/](http://xml.apache.org/commons/components/resolver/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : xmlpull. **Name** : xmlpull. **Version** : 1.1.3.1.
-     * **Project URL:** [http://www.xmlpull.org](http://www.xmlpull.org)
-     * **License:** [Public Domain](http://www.xmlpull.org/v1/download/unpacked/LICENSE.txt)
-
-
-The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
-
-This report was generated on **Mon Oct 07 19:46:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
-
-
-
-
-# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.226`
-
-## Runtime
-1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
-     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
-     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
-     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
-     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
-     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-## Compile, tests, and tooling
-1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
-     * **Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
-     * **License:** Public Domain
-
-1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.48.
-     * **Project URL:** [http://beust.com/jcommander](http://beust.com/jcommander)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.82.
-     * **Project URL:** [https://jcommander.org](https://jcommander.org)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.5.1.
-     * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
-     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.kevinstern. **Name** : software-and-algorithms. **Version** : 1.0.
-     * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
-     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
 
 1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.2.
      * **Project URL:** [https://github.com/google/auto/tree/main/common](https://github.com/google/auto/tree/main/common)
@@ -6147,6 +3412,2749 @@ This report was generated on **Mon Oct 07 19:46:41 WEST 2024** using [Gradle-Lic
 1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.ibm.icu. **Name** : icu4j. **Version** : 67.1.
+     * **Project URL:** [http://icu-project.org/](http://icu-project.org/)
+     * **License:** [Unicode/ICU License](https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE)
+
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-compiler. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-memory-agent. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-gui-forms-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-jshell-protocol. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources-en. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-structure-view. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-uast. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : bootstrap. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : concurrency. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-ui. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor-ex. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : execution. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : icons. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-util-io. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-serialization. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lvcs. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer-annotations. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : remote-core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : resources-en. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ex. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ui. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-zip. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : workspace-model-storage. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.regexp. **Name** : regexp. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.remoteDev. **Name** : remote-dev-util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-dom. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-structure-view. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.rd. **Name** : rd-core. **Version** : 2021.3.5.
+     * **Project URL:** [https://github.com/JetBrains/rd](https://github.com/JetBrains/rd)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.jgoodies. **Name** : forms. **Version** : 1.1-preview.
+     * **Project URL:** [http://www.jgoodies.com/](http://www.jgoodies.com/)
+     * **License:** BSD
+
+1.  **Group** : com.jgoodies. **Name** : jgoodies-common. **Version** : 1.4.0.
+     * **Project URL:** [http://www.jgoodies.com/downloads/libraries.html](http://www.jgoodies.com/downloads/libraries.html)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.html)
+
+1.  **Group** : com.miglayout. **Name** : miglayout-core. **Version** : 11.0.
+     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
+
+1.  **Group** : com.miglayout. **Name** : miglayout-swing. **Version** : 11.0.
+     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
+
+1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
+     * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
+     * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
+1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
+     * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.sun.activation. **Name** : javax.activation. **Version** : 1.2.0.
+     * **Project URL:** [http://www.oracle.com](http://www.oracle.com)
+     * **License:** [CDDL/GPLv2+CE](https://github.com/javaee/activation/blob/master/LICENSE.txt)
+
+1.  **Group** : com.sun.istack. **Name** : istack-commons-runtime. **Version** : 3.0.7.
+     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
+     * **License:** [CDDL 1.1](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
+     * **License:** [GPL2 w/ CPE](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : com.sun.xml.fastinfoset. **Name** : FastInfoset. **Version** : 1.2.15.
+     * **Project URL:** [http://fi.java.net](http://fi.java.net)
+     * **License:** [Apache License, Version 2.0](http://www.opensource.org/licenses/apache2.0.php)
+
+1.  **Group** : com.thoughtworks.xstream. **Name** : xstream. **Version** : 1.4.18.
+     * **Project URL:** [http://x-stream.github.io](http://x-stream.github.io)
+     * **License:** [BSD-3-Clause](http://x-stream.github.io/license.html)
+
+1.  **Group** : com.twelvemonkeys.common. **Name** : common-image. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.common. **Name** : common-io. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.common. **Name** : common-lang. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-core. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-metadata. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-tiff. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
+     * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-codec. **Name** : commons-codec. **Version** : 1.16.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-collections. **Name** : commons-collections. **Version** : 3.2.2.
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-io. **Name** : commons-io. **Version** : 2.11.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-lang. **Name** : commons-lang. **Version** : 2.4.
+     * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-logging. **Name** : commons-logging. **Version** : 1.2.
+     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
+     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
+     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.7.4.
+     * **Project URL:** [https://picocli.info](https://picocli.info)
+     * **License:** [The Apache Software License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.classgraph. **Name** : classgraph. **Version** : 4.8.128.
+     * **Project URL:** [https://github.com/classgraph/classgraph](https://github.com/classgraph/classgraph)
+     * **License:** [The MIT License (MIT)](http://opensource.org/licenses/MIT)
+
+1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
+     * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k. **Version** : 0.4.0.
+     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.eisop. **Name** : dataflow-errorprone. **Version** : 3.34.0-eisop1.
+     * **Project URL:** [https://eisop.github.io/](https://eisop.github.io/)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+
+1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.12.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.x-stream. **Name** : mxparser. **Version** : 1.2.2.
+     * **Project URL:** [http://x-stream.github.io/mxparser](http://x-stream.github.io/mxparser)
+     * **License:** [Indiana University Extreme! Lab Software License](https://raw.githubusercontent.com/x-stream/mxparser/master/LICENSE.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-api. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-cli. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-core. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-metrics. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-parser. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-psi-utils. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-html. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-md. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-sarif. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-txt. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-xml. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-complexity. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-coroutines. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-documentation. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-empty. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-errorprone. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-exceptions. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-naming. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-performance. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-style. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-tooling. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-utils. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-api. **Version** : 5.8.0.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-api-jvm. **Version** : 5.8.0.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-core. **Version** : 5.8.0.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-core-jvm. **Version** : 5.8.0.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-shared. **Version** : 5.8.0.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-shared-jvm. **Version** : 5.8.0.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-common. **Version** : 5.8.0.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-common-jvm. **Version** : 5.8.0.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-buffer. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec-http. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec-http2. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec-socks. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-common. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-handler. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-handler-proxy. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-resolver. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-transport. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : it.unimi.dsi. **Name** : fastutil-core. **Version** : 8.5.12.
+     * **Project URL:** [http://fastutil.di.unimi.it/](http://fastutil.di.unimi.it/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
+
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
+1.  **Group** : javax.inject. **Name** : javax.inject. **Version** : 1.
+     * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : javax.xml.bind. **Name** : jaxb-api. **Version** : 2.3.1.
+     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
+     * **License:** [CDDL 1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **License:** [GPL2 w/ CPE](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1.  **Group** : jaxen. **Name** : jaxen. **Version** : 1.2.0.
+     * **Project URL:** [http://www.cafeconleche.org/jaxen](http://www.cafeconleche.org/jaxen)
+     * **License:** [BSD License 2.0](https://raw.githubusercontent.com/jaxen-xpath/jaxen/master/LICENSE.txt)
+
+1.  **Group** : junit. **Name** : junit. **Version** : 4.13.1.
+     * **Project URL:** [http://junit.org](http://junit.org)
+     * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+1.  **Group** : net.bytebuddy. **Name** : byte-buddy-agent. **Version** : 1.10.1.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.6.0.
+     * **Project URL:** [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
+     * **License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
+
+1.  **Group** : net.jcip. **Name** : jcip-annotations. **Version** : 1.0.
+     * **Project URL:** [http://jcip.net/](http://jcip.net/)
+
+1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 12.2.
+     * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
+     * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.55.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.55.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
+     * **Project URL:** [http://saxon.sourceforge.net/](http://saxon.sourceforge.net/)
+     * **License:** [Mozilla Public License Version 1.0](http://www.mozilla.org/MPL/MPL-1.0.txt)
+
+1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
+     * **License:** [Apache License, Version 2.0](${license.url})
+
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.11.1.
+     * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
+     * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
+
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.7.2.
+     * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
+     * **License:** [The BSD License](http://www.antlr.org/license.html)
+
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
+     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.8.1.
+     * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : fluent-hc. **Version** : 4.5.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : httpclient. **Version** : 4.5.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : httpcore. **Version** : 4.4.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : httpmime. **Version** : 4.5.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.client5. **Name** : httpclient5. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5-h2. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.velocity. **Name** : velocity. **Version** : 1.7.
+     * **Project URL:** [http://velocity.apache.org/engine/devel/](http://velocity.apache.org/engine/devel/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.xmlgraphics. **Name** : xmlgraphics-commons. **Version** : 2.6.
+     * **Project URL:** [http://xmlgraphics.apache.org/commons/](http://xmlgraphics.apache.org/commons/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
+     * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.bouncycastle. **Name** : bcpg-jdk15on. **Version** : 1.69.
+     * **Project URL:** [https://www.bouncycastle.org/java.html](https://www.bouncycastle.org/java.html)
+     * **License:** [Apache Software License, Version 1.1](https://www.apache.org/licenses/LICENSE-1.1)
+     * **License:** [Bouncy Castle Licence](https://www.bouncycastle.org/licence.html)
+
+1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
+     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
+     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.glassfish.jaxb. **Name** : jaxb-runtime. **Version** : 2.3.1.
+     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : org.glassfish.jaxb. **Name** : txw2. **Version** : 2.3.1.
+     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest. **Version** : 2.2.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 2.2.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : org.imgscalr. **Name** : imgscalr-lib. **Version** : 4.2.
+     * **Project URL:** [http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/](http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/)
+     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
+     * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
+     * **License:** [Apache License 2.0](http://www.apache.org/licenses/)
+     * **License:** [LGPL 2.1](http://www.gnu.org/licenses/lgpl-2.1.html)
+     * **License:** [MPL 1.1](http://www.mozilla.org/MPL/MPL-1.1.html)
+
+1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-api. **Version** : 2.28.0.Final.
+     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
+     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
+
+1.  **Group** : org.jboss.forge.roaster. **Name** : roaster-jdt. **Version** : 2.28.0.Final.
+     * **License:** [Eclipse Public License version 1.0](http://www.eclipse.org/legal/epl-v10.html)
+     * **License:** [Public Domain](http://repository.jboss.org/licenses/cc0-1.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.5.2.
+     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.5.2.
+     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : marketplace-zip-signer. **Version** : 0.1.3.
+     * **Project URL:** [https://github.com/JetBrains/marketplace-zip-signer](https://github.com/JetBrains/marketplace-zip-signer)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-kotlin-descriptors. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-markdown. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-base. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij. **Name** : blockmap. **Version** : 1.0.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : commons-imaging. **Version** : 1.0-RC-1.
+     * **Project URL:** [http://commons.apache.org/proper/commons-imaging/](http://commons.apache.org/proper/commons-imaging/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : debugger-memory-agent. **Version** : 1.0.35.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-agent. **Version** : 1.0.613.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-test-discovery-agent. **Version** : 1.0.613.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : ion-java. **Version** : 1.8.2-4.
+     * **Project URL:** [https://github.com/amzn/ion-java/](https://github.com/amzn/ion-java/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : java-compatibility. **Version** : 1.0.1.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jb-jdi. **Version** : 2.16.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
+     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : sa-jdwp. **Version** : 1.20.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
+     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-anim. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-awt-util. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-bridge. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-codec. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-constants. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-css. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-dom. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-ext. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-gvt. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-parser. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svg-dom. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svggen. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-transcoder. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-util. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-xml. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.completion. **Name** : completion-ranking-java. **Version** : 0.3.7.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jcef. **Name** : jcef. **Version** : 89.0.12-g2b76680-chromium-89.0.4389.90-api-1.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.jediterm. **Name** : jediterm-pty. **Version** : 2.64.1.
+     * **Project URL:** [https://github.com/JetBrains/jediterm](https://github.com/JetBrains/jediterm)
+     * **License:** [LGPL 3.0](https://www.gnu.org/licenses/lgpl.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu. **Version** : 0.17.3.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.8.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.9.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.pty4j. **Name** : pty4j. **Version** : 0.12.6.
+     * **Project URL:** [https://github.com/JetBrains/pty4j](https://github.com/JetBrains/pty4j)
+     * **License:** [Eclipse Public License 1.0](https://opensource.org/licenses/eclipse-1.0.php)
+
+1.  **Group** : org.jetbrains.pty4j. **Name** : purejavacomm. **Version** : 0.0.11.1.**No license information found**
+1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.14.2.
+     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
+     * **License:** [The MIT License](https://jsoup.org/license)
+
+1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.16.1.
+     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
+     * **License:** [The MIT License](https://jsoup.org/license)
+
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.jvnet.staxex. **Name** : stax-ex. **Version** : 1.8.
+     * **Project URL:** [http://stax-ex.java.net/](http://stax-ex.java.net/)
+     * **License:** [
+                Dual license consisting of the CDDL v1.1 and GPL v2
+            ](https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : org.jvnet.winp. **Name** : winp. **Version** : 1.28.
+     * **License:** [MIT license](http://www.opensource.org/licenses/mit-license.php)
+     * **License:** [The MIT license](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
+     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.mozilla. **Name** : rhino-runtime. **Version** : 1.7.13.
+     * **Project URL:** [https://developer.mozilla.org/en/Rhino](https://developer.mozilla.org/en/Rhino)
+     * **License:** [Mozilla Public License, Version 2.0](http://www.mozilla.org/MPL/2.0/index.txt)
+
+1.  **Group** : org.objenesis. **Name** : objenesis. **Version** : 3.2.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.6.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-commons. **Version** : 9.6.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-tree. **Version** : 9.6.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 3.1.4.
+     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
+     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.reflections. **Name** : reflections. **Version** : 0.10.2.
+     * **Project URL:** [http://github.com/ronmamo/reflections](http://github.com/ronmamo/reflections)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [WTFPL](http://www.wtfpl.net/)
+
+1.  **Group** : org.snakeyaml. **Name** : snakeyaml-engine. **Version** : 2.6.
+     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.swinglabs. **Name** : swingx-core. **Version** : 1.6.2-2.
+     * **License:** [Lesser General Public License (LGPL)](http://www.gnu.org/copyleft/lesser.html)
+
+1.  **Group** : org.tukaani. **Name** : xz. **Version** : 1.9.
+     * **Project URL:** [https://tukaani.org/xz/java.html](https://tukaani.org/xz/java.html)
+     * **License:** Public Domain
+
+1.  **Group** : org.xmlresolver. **Name** : xmlresolver. **Version** : 5.1.2.
+     * **Project URL:** [https://github.com/xmlresolver/xmlresolver](https://github.com/xmlresolver/xmlresolver)
+     * **License:** [Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
+1.  **Group** : xerces. **Name** : xercesImpl. **Version** : 2.12.1.
+     * **Project URL:** [https://xerces.apache.org/xerces2-j/](https://xerces.apache.org/xerces2-j/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : xml-apis. **Name** : xml-apis-ext. **Version** : 1.3.04.
+     * **Project URL:** [http://xml.apache.org/commons/components/external/](http://xml.apache.org/commons/components/external/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : xml-resolver. **Name** : xml-resolver. **Version** : 1.2.
+     * **Project URL:** [http://xml.apache.org/commons/components/resolver/](http://xml.apache.org/commons/components/resolver/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : xmlpull. **Name** : xmlpull. **Version** : 1.1.3.1.
+     * **Project URL:** [http://www.xmlpull.org](http://www.xmlpull.org)
+     * **License:** [Public Domain](http://www.xmlpull.org/v1/download/unpacked/LICENSE.txt)
+
+
+The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+
+This report was generated on **Thu Oct 24 20:35:43 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+
+
+
+
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-jar:2.0.0-SNAPSHOT.227`
+
+## Runtime
+1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
+     * **Project URL:** [http://nanoxml.cyberelf.be/](http://nanoxml.cyberelf.be/)
+     * **License:** [The zlib/libpng License](http://www.opensource.org/licenses/zlib-license.html)
+
+1.  **Group** : cglib. **Name** : cglib-nodep. **Version** : 3.2.4.
+     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.esotericsoftware.kryo. **Name** : kryo. **Version** : 2.24.0.
+     * **Project URL:** [https://github.com/EsotericSoftware/kryo](https://github.com/EsotericSoftware/kryo)
+     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : com.esotericsoftware.minlog. **Name** : minlog. **Version** : 1.2.
+     * **Project URL:** [http://code.google.com/p/minlog/](http://code.google.com/p/minlog/)
+     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : com.fasterxml. **Name** : aalto-xml. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.jr. **Name** : jackson-jr-objects. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-jr](https://github.com/FasterXML/jackson-jr)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.4.
+     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.spullara.cli-parser. **Name** : cli-parser. **Version** : 1.1.5.
+     * **Project URL:** [http://code.google.com/p/cli-parser/](http://code.google.com/p/cli-parser/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.ibm.icu. **Name** : icu4j. **Version** : 67.1.
+     * **Project URL:** [http://icu-project.org/](http://icu-project.org/)
+     * **License:** [Unicode/ICU License](https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE)
+
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-compiler. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-memory-agent. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-gui-forms-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-jshell-protocol. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources-en. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-structure-view. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-uast. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : bootstrap. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : concurrency. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-ui. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor-ex. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : execution. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : icons. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-util-io. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-serialization. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lvcs. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer-annotations. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : remote-core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : resources-en. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ex. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ui. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-zip. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : workspace-model-storage. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.regexp. **Name** : regexp. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.remoteDev. **Name** : remote-dev-util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-dom. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-structure-view. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.rd. **Name** : rd-core. **Version** : 2021.3.5.
+     * **Project URL:** [https://github.com/JetBrains/rd](https://github.com/JetBrains/rd)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.jgoodies. **Name** : forms. **Version** : 1.1-preview.
+     * **Project URL:** [http://www.jgoodies.com/](http://www.jgoodies.com/)
+     * **License:** BSD
+
+1.  **Group** : com.jgoodies. **Name** : jgoodies-common. **Version** : 1.4.0.
+     * **Project URL:** [http://www.jgoodies.com/downloads/libraries.html](http://www.jgoodies.com/downloads/libraries.html)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.html)
+
+1.  **Group** : com.miglayout. **Name** : miglayout-core. **Version** : 11.0.
+     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
+
+1.  **Group** : com.miglayout. **Name** : miglayout-swing. **Version** : 11.0.
+     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
+
+1.  **Group** : com.sun.activation. **Name** : javax.activation. **Version** : 1.2.0.
+     * **Project URL:** [http://www.oracle.com](http://www.oracle.com)
+     * **License:** [CDDL/GPLv2+CE](https://github.com/javaee/activation/blob/master/LICENSE.txt)
+
+1.  **Group** : com.sun.istack. **Name** : istack-commons-runtime. **Version** : 3.0.7.
+     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
+     * **License:** [CDDL 1.1](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
+     * **License:** [GPL2 w/ CPE](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : com.sun.xml.fastinfoset. **Name** : FastInfoset. **Version** : 1.2.15.
+     * **Project URL:** [http://fi.java.net](http://fi.java.net)
+     * **License:** [Apache License, Version 2.0](http://www.opensource.org/licenses/apache2.0.php)
+
+1.  **Group** : com.thoughtworks.xstream. **Name** : xstream. **Version** : 1.4.18.
+     * **Project URL:** [http://x-stream.github.io](http://x-stream.github.io)
+     * **License:** [BSD-3-Clause](http://x-stream.github.io/license.html)
+
+1.  **Group** : com.twelvemonkeys.common. **Name** : common-image. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.common. **Name** : common-io. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.common. **Name** : common-lang. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-core. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-metadata. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-tiff. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : commons-codec. **Name** : commons-codec. **Version** : 1.16.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-collections. **Name** : commons-collections. **Version** : 3.2.2.
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-io. **Name** : commons-io. **Version** : 2.11.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-lang. **Name** : commons-lang. **Version** : 2.4.
+     * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-logging. **Name** : commons-logging. **Version** : 1.2.
+     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
+     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
+     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : io.github.classgraph. **Name** : classgraph. **Version** : 4.8.128.
+     * **Project URL:** [https://github.com/classgraph/classgraph](https://github.com/classgraph/classgraph)
+     * **License:** [The MIT License (MIT)](http://opensource.org/licenses/MIT)
+
+1.  **Group** : io.github.x-stream. **Name** : mxparser. **Version** : 1.2.2.
+     * **Project URL:** [http://x-stream.github.io/mxparser](http://x-stream.github.io/mxparser)
+     * **License:** [Indiana University Extreme! Lab Software License](https://raw.githubusercontent.com/x-stream/mxparser/master/LICENSE.txt)
+
+1.  **Group** : io.netty. **Name** : netty-buffer. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec-http. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec-http2. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec-socks. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-common. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-handler. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-handler-proxy. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-resolver. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-transport. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
+1.  **Group** : javax.xml.bind. **Name** : jaxb-api. **Version** : 2.3.1.
+     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
+     * **License:** [CDDL 1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **License:** [GPL2 w/ CPE](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1.  **Group** : jaxen. **Name** : jaxen. **Version** : 1.2.0.
+     * **Project URL:** [http://www.cafeconleche.org/jaxen](http://www.cafeconleche.org/jaxen)
+     * **License:** [BSD License 2.0](https://raw.githubusercontent.com/jaxen-xpath/jaxen/master/LICENSE.txt)
+
+1.  **Group** : net.bytebuddy. **Name** : byte-buddy-agent. **Version** : 1.10.1.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : net.jcip. **Name** : jcip-annotations. **Version** : 1.0.
+     * **Project URL:** [http://jcip.net/](http://jcip.net/)
+
+1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
+     * **License:** [Apache License, Version 2.0](${license.url})
+
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
+     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : fluent-hc. **Version** : 4.5.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : httpclient. **Version** : 4.5.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : httpcore. **Version** : 4.4.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : httpmime. **Version** : 4.5.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.velocity. **Name** : velocity. **Version** : 1.7.
+     * **Project URL:** [http://velocity.apache.org/engine/devel/](http://velocity.apache.org/engine/devel/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.xmlgraphics. **Name** : xmlgraphics-commons. **Version** : 2.6.
+     * **Project URL:** [http://xmlgraphics.apache.org/commons/](http://xmlgraphics.apache.org/commons/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.bouncycastle. **Name** : bcpg-jdk15on. **Version** : 1.69.
+     * **Project URL:** [https://www.bouncycastle.org/java.html](https://www.bouncycastle.org/java.html)
+     * **License:** [Apache Software License, Version 1.1](https://www.apache.org/licenses/LICENSE-1.1)
+     * **License:** [Bouncy Castle Licence](https://www.bouncycastle.org/licence.html)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : org.glassfish.jaxb. **Name** : jaxb-runtime. **Version** : 2.3.1.
+     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : org.glassfish.jaxb. **Name** : txw2. **Version** : 2.3.1.
+     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : org.imgscalr. **Name** : imgscalr-lib. **Version** : 4.2.
+     * **Project URL:** [http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/](http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/)
+     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : marketplace-zip-signer. **Version** : 0.1.3.
+     * **Project URL:** [https://github.com/JetBrains/marketplace-zip-signer](https://github.com/JetBrains/marketplace-zip-signer)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij. **Name** : blockmap. **Version** : 1.0.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : commons-imaging. **Version** : 1.0-RC-1.
+     * **Project URL:** [http://commons.apache.org/proper/commons-imaging/](http://commons.apache.org/proper/commons-imaging/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : debugger-memory-agent. **Version** : 1.0.35.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-agent. **Version** : 1.0.613.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-test-discovery-agent. **Version** : 1.0.613.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : ion-java. **Version** : 1.8.2-4.
+     * **Project URL:** [https://github.com/amzn/ion-java/](https://github.com/amzn/ion-java/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : java-compatibility. **Version** : 1.0.1.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jb-jdi. **Version** : 2.16.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
+     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : sa-jdwp. **Version** : 1.20.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
+     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-anim. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-awt-util. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-bridge. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-codec. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-constants. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-css. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-dom. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-ext. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-gvt. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-parser. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svg-dom. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svggen. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-transcoder. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-util. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-xml. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.completion. **Name** : completion-ranking-java. **Version** : 0.3.7.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jcef. **Name** : jcef. **Version** : 89.0.12-g2b76680-chromium-89.0.4389.90-api-1.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.jediterm. **Name** : jediterm-pty. **Version** : 2.64.1.
+     * **Project URL:** [https://github.com/JetBrains/jediterm](https://github.com/JetBrains/jediterm)
+     * **License:** [LGPL 3.0](https://www.gnu.org/licenses/lgpl.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.pty4j. **Name** : pty4j. **Version** : 0.12.6.
+     * **Project URL:** [https://github.com/JetBrains/pty4j](https://github.com/JetBrains/pty4j)
+     * **License:** [Eclipse Public License 1.0](https://opensource.org/licenses/eclipse-1.0.php)
+
+1.  **Group** : org.jetbrains.pty4j. **Name** : purejavacomm. **Version** : 0.0.11.1.**No license information found**
+1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.14.2.
+     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
+     * **License:** [The MIT License](https://jsoup.org/license)
+
+1.  **Group** : org.jvnet.staxex. **Name** : stax-ex. **Version** : 1.8.
+     * **Project URL:** [http://stax-ex.java.net/](http://stax-ex.java.net/)
+     * **License:** [
+                Dual license consisting of the CDDL v1.1 and GPL v2
+            ](https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : org.jvnet.winp. **Name** : winp. **Version** : 1.28.
+     * **License:** [MIT license](http://www.opensource.org/licenses/mit-license.php)
+     * **License:** [The MIT license](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
+     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.mozilla. **Name** : rhino-runtime. **Version** : 1.7.13.
+     * **Project URL:** [https://developer.mozilla.org/en/Rhino](https://developer.mozilla.org/en/Rhino)
+     * **License:** [Mozilla Public License, Version 2.0](http://www.mozilla.org/MPL/2.0/index.txt)
+
+1.  **Group** : org.objenesis. **Name** : objenesis. **Version** : 3.2.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.6.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.swinglabs. **Name** : swingx-core. **Version** : 1.6.2-2.
+     * **License:** [Lesser General Public License (LGPL)](http://www.gnu.org/copyleft/lesser.html)
+
+1.  **Group** : org.tukaani. **Name** : xz. **Version** : 1.9.
+     * **Project URL:** [https://tukaani.org/xz/java.html](https://tukaani.org/xz/java.html)
+     * **License:** Public Domain
+
+1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
+1.  **Group** : xerces. **Name** : xercesImpl. **Version** : 2.12.1.
+     * **Project URL:** [https://xerces.apache.org/xerces2-j/](https://xerces.apache.org/xerces2-j/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : xml-apis. **Name** : xml-apis-ext. **Version** : 1.3.04.
+     * **Project URL:** [http://xml.apache.org/commons/components/external/](http://xml.apache.org/commons/components/external/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : xml-resolver. **Name** : xml-resolver. **Version** : 1.2.
+     * **Project URL:** [http://xml.apache.org/commons/components/resolver/](http://xml.apache.org/commons/components/resolver/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : xmlpull. **Name** : xmlpull. **Version** : 1.1.3.1.
+     * **Project URL:** [http://www.xmlpull.org](http://www.xmlpull.org)
+     * **License:** [Public Domain](http://www.xmlpull.org/v1/download/unpacked/LICENSE.txt)
+
+## Compile, tests, and tooling
+1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
+     * **Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
+     * **License:** Public Domain
+
+1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
+     * **Project URL:** [http://nanoxml.cyberelf.be/](http://nanoxml.cyberelf.be/)
+     * **License:** [The zlib/libpng License](http://www.opensource.org/licenses/zlib-license.html)
+
+1.  **Group** : cglib. **Name** : cglib-nodep. **Version** : 3.2.4.
+     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.48.
+     * **Project URL:** [http://beust.com/jcommander](http://beust.com/jcommander)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.82.
+     * **Project URL:** [https://jcommander.org](https://jcommander.org)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.esotericsoftware.kryo. **Name** : kryo. **Version** : 2.24.0.
+     * **Project URL:** [https://github.com/EsotericSoftware/kryo](https://github.com/EsotericSoftware/kryo)
+     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : com.esotericsoftware.minlog. **Name** : minlog. **Version** : 1.2.
+     * **Project URL:** [http://code.google.com/p/minlog/](http://code.google.com/p/minlog/)
+     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : com.fasterxml. **Name** : aalto-xml. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.jr. **Name** : jackson-jr-objects. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-jr](https://github.com/FasterXML/jackson-jr)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.5.1.
+     * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.4.
+     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
+     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.kevinstern. **Name** : software-and-algorithms. **Version** : 1.0.
+     * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
+     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : com.github.spullara.cli-parser. **Name** : cli-parser. **Version** : 1.1.5.
+     * **Project URL:** [http://code.google.com/p/cli-parser/](http://code.google.com/p/cli-parser/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.2.
+     * **Project URL:** [https://github.com/google/auto/tree/main/common](https://github.com/google/auto/tree/main/common)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.1.1.
+     * **Project URL:** [https://github.com/google/auto/tree/main/service](https://github.com/google/auto/tree/main/service)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/google/auto/tree/main/value](https://github.com/google/auto/tree/main/value)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_check_api](https://errorprone.info/error_prone_check_api)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_core](https://errorprone.info/error_prone_core)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
+     * **Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
+     * **License:** [GNU General Public License, version 2, with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 32.1.3-jre.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.inject. **Name** : guice. **Version** : 5.1.0.
+     * **Project URL:** [https://github.com/google/guice](https://github.com/google/guice)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.ibm.icu. **Name** : icu4j. **Version** : 67.1.
+     * **Project URL:** [http://icu-project.org/](http://icu-project.org/)
+     * **License:** [Unicode/ICU License](https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE)
+
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-analysis-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-compiler. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-debugger-memory-agent. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-execution-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-gui-forms-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-indexing-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-jshell-protocol. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-resources-en. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-structure-view. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.java. **Name** : java-uast. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jsp. **Name** : jsp-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.jvm. **Name** : jvm-analysis-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : analysis-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : bootstrap. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : code-style-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : concurrency. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : core-ui. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : editor-ex. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : execution. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : extensions. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : icons. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-core-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : ide-util-io. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : indexing-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : jps-model-serialization. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lang-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : lvcs. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : object-serializer-annotations. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : project-model-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : remote-core. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : resources-en. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-base. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-class-loader. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ex. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-rt. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-text-matching. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-ui. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-xml-dom. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : util-zip. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.platform. **Name** : workspace-model-storage. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.regexp. **Name** : regexp. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.remoteDev. **Name** : remote-dev-util. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-analysis. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-dom. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-psi-impl. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.intellij.xml. **Name** : xml-structure-view. **Version** : 213.7172.53.**No license information found**
+1.  **Group** : com.jetbrains.rd. **Name** : rd-core. **Version** : 2021.3.5.
+     * **Project URL:** [https://github.com/JetBrains/rd](https://github.com/JetBrains/rd)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.jgoodies. **Name** : forms. **Version** : 1.1-preview.
+     * **Project URL:** [http://www.jgoodies.com/](http://www.jgoodies.com/)
+     * **License:** BSD
+
+1.  **Group** : com.jgoodies. **Name** : jgoodies-common. **Version** : 1.4.0.
+     * **Project URL:** [http://www.jgoodies.com/downloads/libraries.html](http://www.jgoodies.com/downloads/libraries.html)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.html)
+
+1.  **Group** : com.miglayout. **Name** : miglayout-core. **Version** : 11.0.
+     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
+
+1.  **Group** : com.miglayout. **Name** : miglayout-swing. **Version** : 11.0.
+     * **License:** [BSD](http://www.debian.org/misc/bsd.license)
+
+1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
+     * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
+     * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
+1.  **Group** : com.sun.activation. **Name** : javax.activation. **Version** : 1.2.0.
+     * **Project URL:** [http://www.oracle.com](http://www.oracle.com)
+     * **License:** [CDDL/GPLv2+CE](https://github.com/javaee/activation/blob/master/LICENSE.txt)
+
+1.  **Group** : com.sun.istack. **Name** : istack-commons-runtime. **Version** : 3.0.7.
+     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
+     * **License:** [CDDL 1.1](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
+     * **License:** [GPL2 w/ CPE](https://glassfish.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : com.sun.xml.fastinfoset. **Name** : FastInfoset. **Version** : 1.2.15.
+     * **Project URL:** [http://fi.java.net](http://fi.java.net)
+     * **License:** [Apache License, Version 2.0](http://www.opensource.org/licenses/apache2.0.php)
+
+1.  **Group** : com.thoughtworks.xstream. **Name** : xstream. **Version** : 1.4.18.
+     * **Project URL:** [http://x-stream.github.io](http://x-stream.github.io)
+     * **License:** [BSD-3-Clause](http://x-stream.github.io/license.html)
+
+1.  **Group** : com.twelvemonkeys.common. **Name** : common-image. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.common. **Name** : common-io. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.common. **Name** : common-lang. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-core. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-metadata. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : com.twelvemonkeys.imageio. **Name** : imageio-tiff. **Version** : 3.6.1.
+     * **License:** [The BSD License](https://github.com/haraldk/TwelveMonkeys#license)
+
+1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
+     * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-codec. **Name** : commons-codec. **Version** : 1.16.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-collections. **Name** : commons-collections. **Version** : 3.2.2.
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-io. **Name** : commons-io. **Version** : 2.11.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-lang. **Name** : commons-lang. **Version** : 2.4.
+     * **Project URL:** [http://commons.apache.org/lang/](http://commons.apache.org/lang/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-logging. **Name** : commons-logging. **Version** : 1.2.
+     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dk.brics. **Name** : automaton. **Version** : 1.12-1.
+     * **Project URL:** [http://www.brics.dk/automaton](http://www.brics.dk/automaton)
+     * **License:** [BSD](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.7.4.
+     * **Project URL:** [https://picocli.info](https://picocli.info)
+     * **License:** [The Apache Software License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.classgraph. **Name** : classgraph. **Version** : 4.8.128.
+     * **Project URL:** [https://github.com/classgraph/classgraph](https://github.com/classgraph/classgraph)
+     * **License:** [The MIT License (MIT)](http://opensource.org/licenses/MIT)
+
+1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
+     * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k. **Version** : 0.4.0.
+     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.eisop. **Name** : dataflow-errorprone. **Version** : 3.34.0-eisop1.
+     * **Project URL:** [https://eisop.github.io/](https://eisop.github.io/)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+
+1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.12.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.x-stream. **Name** : mxparser. **Version** : 1.2.2.
+     * **Project URL:** [http://x-stream.github.io/mxparser](http://x-stream.github.io/mxparser)
+     * **License:** [Indiana University Extreme! Lab Software License](https://raw.githubusercontent.com/x-stream/mxparser/master/LICENSE.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-api. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-cli. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-core. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-metrics. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-parser. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-psi-utils. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-html. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-md. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-sarif. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-txt. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-xml. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-complexity. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-coroutines. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-documentation. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-empty. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-errorprone. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-exceptions. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-naming. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-performance. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-style. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-tooling. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-utils. **Version** : 1.23.0.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.netty. **Name** : netty-buffer. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec-http. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec-http2. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-codec-socks. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-common. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-handler. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-handler-proxy. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-resolver. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.netty. **Name** : netty-transport. **Version** : 4.1.72.Final.
+     * **Project URL:** [https://netty.io/](https://netty.io/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : it.unimi.dsi. **Name** : fastutil-core. **Version** : 8.5.12.
+     * **Project URL:** [http://fastutil.di.unimi.it/](http://fastutil.di.unimi.it/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
+
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
+1.  **Group** : javax.inject. **Name** : javax.inject. **Version** : 1.
+     * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : javax.xml.bind. **Name** : jaxb-api. **Version** : 2.3.1.
+     * **Project URL:** [http://www.oracle.com/](http://www.oracle.com/)
+     * **License:** [CDDL 1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **License:** [GPL2 w/ CPE](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1.  **Group** : jaxen. **Name** : jaxen. **Version** : 1.2.0.
+     * **Project URL:** [http://www.cafeconleche.org/jaxen](http://www.cafeconleche.org/jaxen)
+     * **License:** [BSD License 2.0](https://raw.githubusercontent.com/jaxen-xpath/jaxen/master/LICENSE.txt)
+
+1.  **Group** : junit. **Name** : junit. **Version** : 4.13.1.
+     * **Project URL:** [http://junit.org](http://junit.org)
+     * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+1.  **Group** : net.bytebuddy. **Name** : byte-buddy-agent. **Version** : 1.10.1.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : net.java.dev.jna. **Name** : jna. **Version** : 5.6.0.
+     * **Project URL:** [https://github.com/java-native-access/jna](https://github.com/java-native-access/jna)
+     * **License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
+
+1.  **Group** : net.jcip. **Name** : jcip-annotations. **Version** : 1.0.
+     * **Project URL:** [http://jcip.net/](http://jcip.net/)
+
+1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 12.2.
+     * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
+     * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.55.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.55.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
+     * **Project URL:** [http://saxon.sourceforge.net/](http://saxon.sourceforge.net/)
+     * **License:** [Mozilla Public License Version 1.0](http://www.mozilla.org/MPL/MPL-1.0.txt)
+
+1.  **Group** : one.util. **Name** : streamex. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/amaembo/streamex](https://github.com/amaembo/streamex)
+     * **License:** [Apache License, Version 2.0](${license.url})
+
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.11.1.
+     * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
+     * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
+
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.7.2.
+     * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
+     * **License:** [The BSD License](http://www.antlr.org/license.html)
+
+1.  **Group** : org.apache.commons. **Name** : commons-compress. **Version** : 1.21.
+     * **Project URL:** [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.8.1.
+     * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : fluent-hc. **Version** : 4.5.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : httpclient. **Version** : 4.5.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : httpcore. **Version** : 4.4.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents. **Name** : httpmime. **Version** : 4.5.13.
+     * **Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.client5. **Name** : httpclient5. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5-h2. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.velocity. **Name** : velocity. **Version** : 1.7.
+     * **Project URL:** [http://velocity.apache.org/engine/devel/](http://velocity.apache.org/engine/devel/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.xmlgraphics. **Name** : xmlgraphics-commons. **Version** : 2.6.
+     * **Project URL:** [http://xmlgraphics.apache.org/commons/](http://xmlgraphics.apache.org/commons/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
+     * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.bouncycastle. **Name** : bcpg-jdk15on. **Version** : 1.69.
+     * **Project URL:** [https://www.bouncycastle.org/java.html](https://www.bouncycastle.org/java.html)
+     * **License:** [Apache Software License, Version 1.1](https://www.apache.org/licenses/LICENSE-1.1)
+     * **License:** [Bouncy Castle Licence](https://www.bouncycastle.org/licence.html)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
+     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.glassfish.jaxb. **Name** : jaxb-runtime. **Version** : 2.3.1.
+     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : org.glassfish.jaxb. **Name** : txw2. **Version** : 2.3.1.
+     * **License:** [CDDL+GPL License](http://glassfish.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest. **Version** : 2.2.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 2.2.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : org.imgscalr. **Name** : imgscalr-lib. **Version** : 4.2.
+     * **Project URL:** [http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/](http://www.thebuzzmedia.com/software/imgscalr-java-image-scaling-library/)
+     * **License:** [ASF 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.ant. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.8.
+     * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
+     * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
+     * **License:** [Apache License 2.0](http://www.apache.org/licenses/)
+     * **License:** [LGPL 2.1](http://www.gnu.org/licenses/lgpl-2.1.html)
+     * **License:** [MPL 1.1](http://www.mozilla.org/MPL/MPL-1.1.html)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations-java5. **Version** : 20.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.5.2.
+     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.5.2.
+     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : marketplace-zip-signer. **Version** : 0.1.3.
+     * **Project URL:** [https://github.com/JetBrains/marketplace-zip-signer](https://github.com/JetBrains/marketplace-zip-signer)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-kotlin-descriptors. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-markdown. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-base. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij. **Name** : blockmap. **Version** : 1.0.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : asm-all. **Version** : 9.2.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : commons-imaging. **Version** : 1.0-RC-1.
+     * **Project URL:** [http://commons.apache.org/proper/commons-imaging/](http://commons.apache.org/proper/commons-imaging/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : debugger-memory-agent. **Version** : 1.0.35.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-coverage-agent. **Version** : 1.0.613.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : intellij-test-discovery-agent. **Version** : 1.0.613.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : ion-java. **Version** : 1.8.2-4.
+     * **Project URL:** [https://github.com/amzn/ion-java/](https://github.com/amzn/ion-java/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : java-compatibility. **Version** : 1.0.1.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jb-jdi. **Version** : 2.16.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : jdom. **Version** : 2.0.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : log4j. **Version** : 1.2.17.2.
+     * **Project URL:** [http://logging.apache.org/log4j/1.2/](http://logging.apache.org/log4j/1.2/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : sa-jdwp. **Version** : 1.20.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
+     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-anim. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-awt-util. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-bridge. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-codec. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-constants. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-css. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-dom. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-ext. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-gvt. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-parser. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svg-dom. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-svggen. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-transcoder. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-util. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.batik. **Name** : batik-xml. **Version** : 1.14.0-24.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps.completion. **Name** : completion-ranking-java. **Version** : 0.3.7.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.fastutil. **Name** : intellij-deps-fastutil. **Version** : 8.5.4-9.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jcef. **Name** : jcef. **Version** : 89.0.12-g2b76680-chromium-89.0.4389.90-api-1.6.**No license information found**
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.intellij.deps.jna. **Name** : jna-platform. **Version** : 5.9.0.26.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-jna](https://github.com/JetBrains/intellij-deps-jna)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [LGPL-2.1-or-later](https://www.gnu.org/licenses/old-licenses/lgpl-2.1)
+
+1.  **Group** : org.jetbrains.jediterm. **Name** : jediterm-pty. **Version** : 2.64.1.
+     * **Project URL:** [https://github.com/JetBrains/jediterm](https://github.com/JetBrains/jediterm)
+     * **License:** [LGPL 3.0](https://www.gnu.org/licenses/lgpl.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.8.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.9.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.pty4j. **Name** : pty4j. **Version** : 0.12.6.
+     * **Project URL:** [https://github.com/JetBrains/pty4j](https://github.com/JetBrains/pty4j)
+     * **License:** [Eclipse Public License 1.0](https://opensource.org/licenses/eclipse-1.0.php)
+
+1.  **Group** : org.jetbrains.pty4j. **Name** : purejavacomm. **Version** : 0.0.11.1.**No license information found**
+1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.14.2.
+     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
+     * **License:** [The MIT License](https://jsoup.org/license)
+
+1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.16.1.
+     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
+     * **License:** [The MIT License](https://jsoup.org/license)
+
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.10.0.
+     * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.jvnet.staxex. **Name** : stax-ex. **Version** : 1.8.
+     * **Project URL:** [http://stax-ex.java.net/](http://stax-ex.java.net/)
+     * **License:** [
+                Dual license consisting of the CDDL v1.1 and GPL v2
+            ](https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html)
+
+1.  **Group** : org.jvnet.winp. **Name** : winp. **Version** : 1.28.
+     * **License:** [MIT license](http://www.opensource.org/licenses/mit-license.php)
+     * **License:** [The MIT license](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.lz4. **Name** : lz4-pure-java. **Version** : 1.8.0.
+     * **Project URL:** [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.mozilla. **Name** : rhino-runtime. **Version** : 1.7.13.
+     * **Project URL:** [https://developer.mozilla.org/en/Rhino](https://developer.mozilla.org/en/Rhino)
+     * **License:** [Mozilla Public License, Version 2.0](http://www.mozilla.org/MPL/2.0/index.txt)
+
+1.  **Group** : org.objenesis. **Name** : objenesis. **Version** : 3.2.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.6.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-commons. **Version** : 9.6.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-tree. **Version** : 9.6.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 3.1.4.
+     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
+     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.reflections. **Name** : reflections. **Version** : 0.10.2.
+     * **Project URL:** [http://github.com/ronmamo/reflections](http://github.com/ronmamo/reflections)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [WTFPL](http://www.wtfpl.net/)
+
+1.  **Group** : org.snakeyaml. **Name** : snakeyaml-engine. **Version** : 2.6.
+     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.swinglabs. **Name** : swingx-core. **Version** : 1.6.2-2.
+     * **License:** [Lesser General Public License (LGPL)](http://www.gnu.org/copyleft/lesser.html)
+
+1.  **Group** : org.tukaani. **Name** : xz. **Version** : 1.9.
+     * **Project URL:** [https://tukaani.org/xz/java.html](https://tukaani.org/xz/java.html)
+     * **License:** Public Domain
+
+1.  **Group** : org.xmlresolver. **Name** : xmlresolver. **Version** : 5.1.2.
+     * **Project URL:** [https://github.com/xmlresolver/xmlresolver](https://github.com/xmlresolver/xmlresolver)
+     * **License:** [Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : oro. **Name** : oro. **Version** : 2.0.8.**No license information found**
+1.  **Group** : xerces. **Name** : xercesImpl. **Version** : 2.12.1.
+     * **Project URL:** [https://xerces.apache.org/xerces2-j/](https://xerces.apache.org/xerces2-j/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : xml-apis. **Name** : xml-apis-ext. **Version** : 1.3.04.
+     * **Project URL:** [http://xml.apache.org/commons/components/external/](http://xml.apache.org/commons/components/external/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : xml-resolver. **Name** : xml-resolver. **Version** : 1.2.
+     * **Project URL:** [http://xml.apache.org/commons/components/resolver/](http://xml.apache.org/commons/components/resolver/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : xmlpull. **Name** : xmlpull. **Version** : 1.1.3.1.
+     * **Project URL:** [http://www.xmlpull.org](http://www.xmlpull.org)
+     * **License:** [Public Domain](http://www.xmlpull.org/v1/download/unpacked/LICENSE.txt)
+
+
+The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+
+This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+
+
+
+
+# Dependencies of `io.spine.tools:spine-psi-java-bundle-test:2.0.0-SNAPSHOT.227`
+
+## Runtime
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.23.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+## Compile, tests, and tooling
+1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
+     * **Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
+     * **License:** Public Domain
+
+1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.48.
+     * **Project URL:** [http://beust.com/jcommander](http://beust.com/jcommander)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.82.
+     * **Project URL:** [https://jcommander.org](https://jcommander.org)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
+     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.5.1.
+     * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
+     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.kevinstern. **Name** : software-and-algorithms. **Version** : 1.0.
+     * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
+     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.2.
+     * **Project URL:** [https://github.com/google/auto/tree/main/common](https://github.com/google/auto/tree/main/common)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.1.1.
+     * **Project URL:** [https://github.com/google/auto/tree/main/service](https://github.com/google/auto/tree/main/service)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/google/auto/tree/main/value](https://github.com/google/auto/tree/main/value)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_check_api](https://errorprone.info/error_prone_check_api)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_core](https://errorprone.info/error_prone_core)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
+     * **Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
+     * **License:** [GNU General Public License, version 2, with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
+
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 32.1.3-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 32.1.3-jre.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.inject. **Name** : guice. **Version** : 5.1.0.
+     * **Project URL:** [https://github.com/google/guice](https://github.com/google/guice)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 2.8.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-gradle-plugin. **Version** : 0.9.4.
+     * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
+     * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
@@ -6645,12 +6653,12 @@ This report was generated on **Mon Oct 07 19:46:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:46:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.227`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6663,6 +6671,10 @@ This report was generated on **Mon Oct 07 19:46:41 WEST 2024** using [Gradle-Lic
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.23.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -6720,10 +6732,6 @@ This report was generated on **Mon Oct 07 19:46:41 WEST 2024** using [Gradle-Lic
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.23.
-     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.23.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -7451,4 +7459,4 @@ This report was generated on **Mon Oct 07 19:46:41 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 07 19:46:41 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 20:35:44 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -748,7 +748,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 21:47:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:13:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1616,7 +1616,7 @@ This report was generated on **Thu Oct 24 21:47:23 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 21:47:23 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:13:28 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2623,7 +2623,7 @@ This report was generated on **Thu Oct 24 21:47:23 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 21:47:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:13:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4308,7 +4308,7 @@ This report was generated on **Thu Oct 24 21:47:24 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 21:47:24 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:13:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5928,7 +5928,7 @@ This report was generated on **Thu Oct 24 21:47:24 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 21:47:25 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:13:29 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6629,7 +6629,7 @@ This report was generated on **Thu Oct 24 21:47:25 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 21:47:25 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:13:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7431,4 +7431,4 @@ This report was generated on **Thu Oct 24 21:47:25 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 24 21:47:25 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Oct 24 22:13:30 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/protobuf/ProjectExts.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/protobuf/ProjectExts.kt
@@ -60,7 +60,7 @@ public val Project.protobufExtension: ProtobufExtension?
  * modify the value of the property either.
  */
 public val Project.generatedSourceProtoDir: Path
-    get() = buildDir.resolve("generated/source/proto").toPath()
+    get() = layout.buildDirectory.dir("generated/source/proto").get().asFile.toPath()
 
 /**
  * Obtains an absolute path to the generated code directory of this project.

--- a/pom.xml
+++ b/pom.xml
@@ -330,12 +330,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jacoco</groupId>
     <artifactId>org.jacoco.agent</artifactId>
-    <version>0.8.8</version>
+    <version>0.8.12</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>
     <artifactId>org.jacoco.ant</artifactId>
-    <version>0.8.8</version>
+    <version>0.8.12</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.dokka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.226</version>
+<version>2.0.0-SNAPSHOT.227</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -146,13 +146,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.212</version>
+    <version>2.0.0-SNAPSHOT.215</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.233</version>
+    <version>2.0.0-SNAPSHOT.240</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/psi-java-bundle-jar/build.gradle.kts
+++ b/psi-java-bundle-jar/build.gradle.kts
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import io.spine.internal.dependency.Spine
 import io.spine.internal.gradle.publish.SpinePublishing
 
 plugins {
@@ -70,6 +71,22 @@ tasks.publish {
 }
 
 tasks.shadowJar {
+    dependencies {
+        exclude(dependency(Spine.base))
+        exclude(dependency(Spine.reflect))
+        with(Spine.Logging) {
+            arrayOf(
+                lib,
+                libJvm,
+                platformGenerator,
+                julBackend,
+                jvmDefaultPlatform,
+                middleware
+            ).forEach {
+                exclude(dependency(it))
+            }
+        }
+    }
     exclude(
         /*
           Exclude IntelliJ Platform images and other resources associated with IntelliJ UI.
@@ -173,9 +190,8 @@ tasks.shadowJar {
          * See: `https://github.com/jenkinsci/winp`.
          */
         "winp.dll",
-        "winp.x64.dll"
+        "winp.x64.dll",
     )
-
     setZip64(true)  /* The archive has way too many items. So using the Zip64 mode. */
     archiveClassifier.set("")  /** To prevent Gradle setting something like `osx-x86_64`. */
     mergeServiceFiles("desc.ref")

--- a/psi-java-bundle-test/build.gradle.kts
+++ b/psi-java-bundle-test/build.gradle.kts
@@ -39,10 +39,10 @@
 val ABOUT = ""
 
 val psiJavaProject = project(":psi-java")
-val psiJavaBuildDir = psiJavaProject.buildDir
+val psiJavaBuildDir: DirectoryProperty = psiJavaProject.layout.buildDirectory
 val psiTestClasses = files(
-    psiJavaBuildDir.resolve("classes/kotlin/test"),
-    psiJavaBuildDir.resolve("resources/test"),
+    psiJavaBuildDir.dir("classes/kotlin/test"),
+    psiJavaBuildDir.dir("resources/test"),
 )
 
 val psiBundleJarProject = project(":psi-java-bundle-jar")
@@ -57,4 +57,7 @@ dependencies {
 
 tasks.test {
     testClassesDirs = psiTestClasses
+    dependsOn(psiJavaProject.tasks.getByName("compileTestKotlin"))
+    dependsOn(psiJavaProject.tasks.getByName("processTestResources"))
+    dependsOn(psiBundleJarProject.tasks.getByName("jar"))
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.226")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.227")


### PR DESCRIPTION
This PR updates dependency on Logging and other related internal dependencies. Also this PR removes unwanted code from `psi-java-bundle`.

## Trimming in `psi-java-bundle`
The build script was updated to exclude libraries we use (e.g. Guava and Protobuf) from being packed into the fat JAR. This code will be available in the classpath anyway. Even if PSI uses some of these libraries, we do want to have predictable versions of the classes. If we face the conflict with PSI, we'd try to address it via repackaging.

Also, Spine libraries were removed as archived dependencies. Again, this code is going to be in the classpath anyway.

## Other notable changes
 * Gradle bumped to `8.10.2`.
 * `config` was updated.
