### PR TITLE
Fix publishing task dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/intellij-platform-jar.gradle.kts
+++ b/buildSrc/src/main/kotlin/intellij-platform-jar.gradle.kts
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("UnstableApiUsage") // `configurations` block.
+
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import io.spine.internal.dependency.Kotlin
 import io.spine.internal.gradle.publish.IncrementGuard
@@ -78,10 +80,20 @@ publishing {
 }
 
 /**
- * Declare dependency explicitly to address the Gradle warning.
+ * Declare dependency explicitly to address the Gradle error.
  */
 @Suppress("unused")
 val publishFatJarPublicationToMavenLocal: Task by tasks.getting {
+    dependsOn(tasks.jar)
+}
+
+@Suppress("unused")
+val publishFatJarPublicationToMavenRepository: Task by tasks.getting {
+    dependsOn(tasks.jar)
+}
+
+@Suppress("unused")
+val publishFatJarPublicationToMaven2Repository: Task by tasks.getting {
     dependsOn(tasks.jar)
 }
 

--- a/buildSrc/src/main/kotlin/intellij-platform-jar.gradle.kts
+++ b/buildSrc/src/main/kotlin/intellij-platform-jar.gradle.kts
@@ -84,17 +84,12 @@ publishing {
  */
 @Suppress("unused")
 val publishFatJarPublicationToMavenLocal: Task by tasks.getting {
-    dependsOn(tasks.jar)
+    dependsOn(tasks.shadowJar)
 }
 
-@Suppress("unused")
-val publishFatJarPublicationToMavenRepository: Task by tasks.getting {
-    dependsOn(tasks.jar)
-}
-
-@Suppress("unused")
-val publishFatJarPublicationToMaven2Repository: Task by tasks.getting {
-    dependsOn(tasks.jar)
+// Disable the `jar` task to free up the name of the resulting archive.
+tasks.jar {
+    enabled = false
 }
 
 tasks.publish {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
@@ -174,14 +174,14 @@ internal class StandardJavaPublicationHandler(
      *
      * A typical Maven publication contains:
      *
-     *  1. Jar archives. For example: compilation output, sources, javadoc, etc.
-     *  2. Maven metadata file that has ".pom" extension.
-     *  3. Gradle's metadata file that has ".module" extension.
+     *  1. Jar archives. For example, compilation output, sources, javadoc, etc.
+     *  2. Maven metadata file that has the ".pom" extension.
+     *  3. Gradle's metadata file that has the ".module" extension.
      *
-     *  Metadata files contain information about a publication itself, its artifacts and their
+     *  Metadata files contain information about a publication itself, its artifacts, and their
      *  dependencies. Presence of ".pom" file is mandatory for publication to be consumed by
      *  `mvn` build tool itself or other build tools that understand Maven notation (Gradle, Ivy).
-     *  Presence of ".module" is optional, but useful when a publication is consumed by Gradle.
+     *  The presence of ".module" is optional, but useful when a publication is consumed by Gradle.
      *
      * @see <a href="https://maven.apache.org/pom.html">Maven – POM Reference</a>
      * @see <a href="https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html">

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.231`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.232`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -493,12 +493,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 26 17:00:03 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 26 18:01:31 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.231`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.232`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -1752,12 +1752,12 @@ This report was generated on **Sat Oct 26 17:00:03 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 26 17:00:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 26 18:01:31 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.231`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.232`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2505,12 +2505,12 @@ This report was generated on **Sat Oct 26 17:00:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 26 17:00:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 26 18:01:31 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.231`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.232`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -3373,12 +3373,12 @@ This report was generated on **Sat Oct 26 17:00:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 26 17:00:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 26 18:01:32 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.231`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.232`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4380,12 +4380,12 @@ This report was generated on **Sat Oct 26 17:00:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 26 17:00:04 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 26 18:01:32 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.231`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.232`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -6065,12 +6065,12 @@ This report was generated on **Sat Oct 26 17:00:04 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 26 17:00:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 26 18:01:32 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.231`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.232`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6867,4 +6867,4 @@ This report was generated on **Sat Oct 26 17:00:05 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 26 17:00:05 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 26 18:01:33 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.231</version>
+<version>2.0.0-SNAPSHOT.232</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.231")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.232")


### PR DESCRIPTION
This PR disables the `jar` task in modules related to IntelliJ Platform to avoid the Gradle task dependency error, which occurs after migrating to `8.10.2`.