### PR TITLE
Redirect PSI errors to the default exception handler

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.240`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.241`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -493,12 +493,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 15 16:11:25 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 14 15:55:52 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.240`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.241`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -1752,12 +1752,12 @@ This report was generated on **Sun Dec 15 16:11:25 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 15 16:11:25 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 14 15:55:52 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.240`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.241`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2505,12 +2505,12 @@ This report was generated on **Sun Dec 15 16:11:25 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 15 16:11:26 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 14 15:55:53 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.240`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.241`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -3373,12 +3373,12 @@ This report was generated on **Sun Dec 15 16:11:26 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 15 16:11:26 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 14 15:55:53 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.240`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.241`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4380,12 +4380,12 @@ This report was generated on **Sun Dec 15 16:11:26 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 15 16:11:26 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 14 15:55:53 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.240`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.241`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -6065,12 +6065,12 @@ This report was generated on **Sun Dec 15 16:11:26 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 15 16:11:27 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 14 15:55:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.240`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.241`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6867,4 +6867,4 @@ This report was generated on **Sun Dec 15 16:11:27 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 15 16:11:27 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 14 15:55:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.240</version>
+<version>2.0.0-SNAPSHOT.241</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiCommands.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiCommands.kt
@@ -52,6 +52,7 @@ import kotlin.system.exitProcess
  *
  * @see executeSilent
  */
+@JvmOverloads
 @JvmName("execute")
 @Suppress("TooGenericExceptionCaught") // We need everything, including `java.lang.Error`.
 public fun execute(errorHandler: (Throwable) -> Unit = ::logAndTerminate, runnable: Runnable) {

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiCommands.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiCommands.kt
@@ -54,7 +54,7 @@ import kotlin.system.exitProcess
  */
 @JvmName("execute")
 @Suppress("TooGenericExceptionCaught") // We need everything, including `java.lang.Error`.
-public fun execute(runnable: Runnable, errorHandler: (Throwable) -> Unit = ::logAndTerminate) {
+public fun execute(errorHandler: (Throwable) -> Unit = ::logAndTerminate, runnable: Runnable) {
     val withHandledErrors = Runnable {
         try {
             runnable.run()

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiCommands.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiCommands.kt
@@ -29,6 +29,7 @@ package io.spine.tools.psi.java
 import com.intellij.openapi.command.CommandProcessor
 import io.spine.tools.psi.java.Environment.commandProcessor
 import io.spine.tools.psi.java.Environment.project
+import java.lang.Thread.getDefaultUncaughtExceptionHandler
 
 /**
  * Executes the given [Runnable] as a PSI modification
@@ -36,5 +37,37 @@ import io.spine.tools.psi.java.Environment.project
  */
 @JvmName("execute")
 public fun execute(runnable: Runnable) {
-    commandProcessor.executeCommand(project, runnable, null, null)
+    val command = withRedirectedErrors(runnable)
+    commandProcessor.executeCommand(project, command, null, null)
+}
+
+/**
+ * Wraps the given [runnable] in a try-catch block, redirecting any [Throwable]
+ * to the default uncaught exception handler.
+ *
+ * The `CoreCommandProcessor` used by PSI for command handling swallows any
+ * [Throwable] from the passed [Runnable]. As a result, PSI users cannot know
+ * if an error has occurred. For example, ProtoData is expected to print
+ * the stacktrace and exist the application in case of error or exception,
+ * but this behavior is suppressed by PSI.
+ *
+ * This method addresses this issue by wrapping the given [runnable] in its own
+ * try-catch block, redirecting all errors and exceptions to the default handler.
+ * This ensures that PSI does not swallow these exceptions. However, as a consequence,
+ * the default exception handler must be explicitly set, as redirection only works
+ * when an explicit handler is in place.
+ *
+ * Note: to make this method work, the default exception handler must be set explicitly
+ * using [Thread.setDefaultUncaughtExceptionHandler]. Otherwise, a [NullPointerException]
+ * will be thrown and swallowed by PSI, making this method ineffective.
+ */
+@Suppress("TooGenericExceptionCaught")
+private fun withRedirectedErrors(runnable: Runnable) = Runnable {
+    try {
+        runnable.run()
+    } catch (e: Throwable) {
+        val currentThread = Thread.currentThread()
+        val globalHandler = getDefaultUncaughtExceptionHandler()
+        globalHandler.uncaughtException(currentThread, e)
+    }
 }

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiCommands.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiCommands.kt
@@ -48,6 +48,7 @@ import kotlin.system.exitProcess
  * @see executeSilent
  */
 @JvmName("execute")
+@Suppress("TooGenericExceptionCaught") // `CoreCommandProcessor` also catches `Throwable`.
 public fun execute(runnable: Runnable) {
     val withCaughtErrors = Runnable {
         try {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.240")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.241")


### PR DESCRIPTION
This PR wraps the `runnable` we give to PSI into a `try-catch` block, with the configurable possibility to throw right away.

We need this change, so that users of ProtoData could see these errors.

I have tested this approach locally with changes to `tool-base` and `ProtoData`, it works. And I have not found any usages of `commandProcessor.executeCommand()` out of this extension, which we use as an entry point to PSI modifications.

Addresses problem (2) described in [this](https://github.com/SpineEventEngine/core-java/pull/1564#issuecomment-2582440484) comment.