### PR TITLE
Move extensions from `validation` library

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.241`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.242`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -493,12 +493,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 14 15:55:52 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:11:27 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.241`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.242`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -1752,12 +1752,12 @@ This report was generated on **Tue Jan 14 15:55:52 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 14 15:55:52 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:11:28 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.241`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.242`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2505,12 +2505,12 @@ This report was generated on **Tue Jan 14 15:55:52 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 14 15:55:53 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:11:28 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.241`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.242`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -3373,12 +3373,12 @@ This report was generated on **Tue Jan 14 15:55:53 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 14 15:55:53 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:11:29 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.241`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.242`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4380,12 +4380,12 @@ This report was generated on **Tue Jan 14 15:55:53 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 14 15:55:53 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:11:29 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.241`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.242`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -6065,12 +6065,12 @@ This report was generated on **Tue Jan 14 15:55:53 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 14 15:55:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:11:29 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.241`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.242`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6867,4 +6867,4 @@ This report was generated on **Tue Jan 14 15:55:54 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 14 15:55:54 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 27 16:11:30 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.241</version>
+<version>2.0.0-SNAPSHOT.242</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
@@ -209,3 +209,62 @@ public fun PsiClass.implement(superInterface: PsiJavaCodeReferenceElement) {
         implements.add(superInterface)
     }
 }
+
+/**
+ * Looks for a nested class declared in this [PsiClass].
+ *
+ * @param simpleName The simple name of the class.
+ * @return The found class, or `null`.
+ */
+public fun PsiClass.findNested(simpleName: String): PsiClass? =
+    innerClasses.firstOrNull { it.name == simpleName }
+
+/**
+ * Returns a nested class declared in this [PsiClass].
+ *
+ * @param simpleName The simple name of the class.
+ * @throws IllegalStateException if this [PsiClass] doesn't have such a class.
+ */
+public fun PsiClass.nested(simpleName: String): PsiClass =
+    innerClasses.firstOrNull { it.name == simpleName }
+        ?: error {
+            "The class `$qualifiedName` does not have a nested class named `$name`."
+        }
+
+/**
+ * Looks for a method in this [PsiClass] matching the given signature
+ * specified as [text].
+ *
+ * An example usage:
+ *
+ * ```
+ * val method = psiClass.findMethodBySignature("public Builder setName(Name value)")
+ * ```
+ *
+ * @param text The method signature as text.
+ * @return The found [PsiMethod], or `null`.
+ */
+public fun PsiClass.findMethodBySignature(text: String): PsiMethod? {
+    val reference = elementFactory.createMethodFromText(text, null)
+    return findMethodBySignature(reference, false)
+}
+
+/**
+ * Returns a method from this [PsiClass] matching the given signature
+ * specified as [text].
+ *
+ * An example usage:
+ *
+ * ```
+ * val method = psiClass.getMethodBySignature("public Builder setName(Name value)")
+ * ```
+ *
+ * @param text The method signature as text.
+ * @throws IllegalStateException if this class does not have such a method.
+ */
+public fun PsiClass.methodWithSignature(text: String): PsiMethod =
+    findMethodBySignature(text)
+        ?: error(
+            "Could not find the method with the signature `$text` " +
+                    "in the `$qualifiedName` class."
+        )

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiClassExts.kt
@@ -214,7 +214,7 @@ public fun PsiClass.implement(superInterface: PsiJavaCodeReferenceElement) {
  * Looks for a nested class declared in this [PsiClass].
  *
  * @param simpleName The simple name of the class.
- * @return The found class, or `null`.
+ * @return The found class, or `null` if this [PsiClass] does not have such a class.
  */
 public fun PsiClass.findNested(simpleName: String): PsiClass? =
     innerClasses.firstOrNull { it.name == simpleName }
@@ -223,7 +223,7 @@ public fun PsiClass.findNested(simpleName: String): PsiClass? =
  * Returns a nested class declared in this [PsiClass].
  *
  * @param simpleName The simple name of the class.
- * @throws IllegalStateException if this [PsiClass] doesn't have such a class.
+ * @throws IllegalStateException if this [PsiClass] does not have such a class.
  */
 public fun PsiClass.nested(simpleName: String): PsiClass =
     innerClasses.firstOrNull { it.name == simpleName }
@@ -242,7 +242,7 @@ public fun PsiClass.nested(simpleName: String): PsiClass =
  * ```
  *
  * @param text The method signature as text.
- * @return The found [PsiMethod], or `null`.
+ * @return The found [PsiMethod], or `null` if this class does not have such a method.
  */
 public fun PsiClass.findMethodBySignature(text: String): PsiMethod? {
     val reference = elementFactory.createMethodFromText(text, null)

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementExts.kt
@@ -36,7 +36,7 @@ import com.intellij.psi.PsiElement
  * So, the second direct child of this [PsiElement] is checked only
  * when the first child and all its descendants are checked.
  *
- * @return the found element, or `null`.
+ * @return the found element, or `null` if this [PsiElement] does not contain such an element.
  */
 public fun PsiElement.findFirstByText(
     startsWith: String,
@@ -58,8 +58,7 @@ public fun PsiElement.findFirstByText(
  * So, the second direct child of this [PsiElement] is checked only
  * when the first child and all its descendants are checked.
  *
- * @return the found element, or `null`.
- * @throws [IllegalStateException] if this [PsiElement] doesn't contain such an element.
+ * @throws [IllegalStateException] if this [PsiElement] does not contain such an element.
  */
 public fun PsiElement.getFirstByText(
     startsWith: String,

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementExts.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.psi.java
+
+import com.intellij.psi.PsiElement
+
+/**
+ * Looks for the first child of this [PsiElement], the text representation
+ * of which satisfies both [startsWith] and [contains] criteria.
+ *
+ * This method performs a depth-first search of the PSI hierarchy.
+ * So, the second direct child of this [PsiElement] is checked only
+ * when the first child and all its descendants are checked.
+ *
+ * @return the found element, or `null`.
+ */
+public fun PsiElement.findFirstByText(
+    startsWith: String,
+    contains: String = startsWith
+): PsiElement? = children.firstNotNullOfOrNull { element ->
+    val text = element.text
+    when {
+        !text.contains(contains) -> null
+        text.startsWith(startsWith) -> element
+        else -> element.findFirstByText(startsWith, contains)
+    }
+}
+
+/**
+ * Returns the first child of this [PsiElement], the text representation
+ * of which satisfies both [startsWith] and [contains] criteria.
+ *
+ * This method performs a depth-first search of the PSI hierarchy.
+ * So, the second direct child of this [PsiElement] is checked only
+ * when the first child and all its descendants are checked.
+ *
+ * @return the found element, or `null`.
+ * @throws [IllegalArgumentException] if this [PsiElement] doesn't contain such an element.
+ */
+public fun PsiElement.getFirstByText(
+    startsWith: String,
+    contains: String = startsWith
+): PsiElement {
+    val result = findFirstByText(startsWith, contains)
+    require(result != null) {
+        "The element was not found." +
+                "Search criteria: [startsWith=`$startsWith`, contains=`$contains`]." +
+                "Searched element: `$this`."
+    }
+    return result
+}

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementExts.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiElementExts.kt
@@ -59,17 +59,15 @@ public fun PsiElement.findFirstByText(
  * when the first child and all its descendants are checked.
  *
  * @return the found element, or `null`.
- * @throws [IllegalArgumentException] if this [PsiElement] doesn't contain such an element.
+ * @throws [IllegalStateException] if this [PsiElement] doesn't contain such an element.
  */
 public fun PsiElement.getFirstByText(
     startsWith: String,
     contains: String = startsWith
-): PsiElement {
-    val result = findFirstByText(startsWith, contains)
-    require(result != null) {
-        "The element was not found." +
-                "Search criteria: [startsWith=`$startsWith`, contains=`$contains`]." +
-                "Searched element: `$this`."
-    }
-    return result
-}
+): PsiElement =
+    findFirstByText(startsWith, contains)
+        ?: error {
+            "The element was not found." +
+                    "Search criteria: [startsWith=`$startsWith`, contains=`$contains`]." +
+                    "Searched element: `$this`."
+        }

--- a/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiStatements.kt
+++ b/psi-java/src/main/kotlin/io/spine/tools/psi/java/PsiStatements.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.psi.java
+
+import com.intellij.psi.PsiCodeBlock
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementFactory
+
+/**
+ * A list of statements extracted from the given [PsiCodeBlock],
+ * excluding the surrounding braces.
+ *
+ * This type addresses several challenges:
+ *
+ * 1. In PSI, a code block cannot be created without curly braces. As a result, even if
+ *    you only need a list of statements, you must create a full block with braces.
+ * 2. Inserting such a block into another code block requires range copying
+ *    to skip the braces.
+ * 3. While a list of statements can be [retrieved][PsiCodeBlock.getStatements] directly from
+ *    the code block, formatting elements like whitespace and newlines are omitted, leaving
+ *    only the raw statements. Adding these statements individually to a method body often
+ *    results in invalid or non-compilable Java code.
+ */
+public class PsiStatements(codeBlock: PsiCodeBlock) {
+
+    /**
+     * All children of [PsiCodeBlock] without right and left braces.
+     */
+    private val children = codeBlock.children
+        .copyOfRange(1, codeBlock.children.size - 1)
+
+    /**
+     * Returns the first child of this element.
+     */
+    public val firstChild: PsiElement = children.first()
+
+    /**
+     * Returns the last child of this element.
+     */
+    public val lastChild: PsiElement = children.last()
+}
+
+/**
+ * Creates a new [PsiStatements] from the given [text].
+ *
+ * @param text The text of the statements to create.
+ * @param context The PSI element used as context for resolving references.
+ */
+public fun PsiElementFactory.createStatementsFromText(
+    text: String,
+    context: PsiElement?
+): PsiStatements {
+    val codeBlock = createCodeBlockFromText("{$text}", context)
+    return PsiStatements(codeBlock)
+}
+
+/**
+ * Adds the given [statements] to this [PsiElement].
+ */
+public fun PsiElement.add(statements: PsiStatements) {
+    addRange(statements.firstChild, statements.lastChild)
+}
+
+/**
+ * Adds the given [statements] to this [PsiElement] after the [anchor].
+ */
+public fun PsiElement.addAfter(statements: PsiStatements, anchor: PsiElement) {
+    addRangeAfter(statements.firstChild, statements.lastChild, anchor)
+}
+
+/**
+ * Adds the given [statements] to this [PsiElement] before the [anchor].
+ */
+public fun PsiElement.addBefore(statements: PsiStatements, anchor: PsiElement) {
+    addRangeBefore(statements.firstChild, statements.lastChild, anchor)
+}

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/TestFixtures.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/TestFixtures.kt
@@ -39,3 +39,12 @@ internal fun readResource(fileName: String): String {
     val code = loaded.convertLineSeparators()
     return code
 }
+
+/**
+ * A signature of [com.google.protobuf.Message.Builder.mergeFrom] method.
+ */
+internal val MERGE_FROM_SIGNATURE = """
+        public Builder mergeFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+""".trimIndent()

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
@@ -31,10 +31,12 @@ import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiJavaCodeReferenceElement
 import com.intellij.psi.PsiMethod
 import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.spine.testing.TestValues
 import io.spine.tools.java.reference
+import io.spine.tools.psi.MERGE_FROM_SIGNATURE
 import io.spine.tools.psi.java.Environment.elementFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -75,6 +77,20 @@ internal class PsiClassExtsSpec: PsiTest() {
         }
         method.isStatic shouldBe true
         method.isPublic shouldBe true
+    }
+
+    @Test
+    fun `find a method by its signature`() {
+        val psiFile = parse("FieldPath.java")
+        val psiClass = psiFile.topLevelClass.nested("Builder")
+        psiClass.findMethodBySignature(MERGE_FROM_SIGNATURE).shouldNotBeNull()
+    }
+
+    @Test
+    fun `return a nested class`() {
+        val psiFile = parse("FieldPath.java")
+        psiFile.topLevelClass
+            .findNested("Builder").shouldNotBeNull()
     }
 
     @Test

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiClassExtsSpec.kt
@@ -89,8 +89,8 @@ internal class PsiClassExtsSpec: PsiTest() {
     @Test
     fun `return a nested class`() {
         val psiFile = parse("FieldPath.java")
-        psiFile.topLevelClass
-            .findNested("Builder").shouldNotBeNull()
+        val psiClass = psiFile.topLevelClass.findNested("Builder")
+        psiClass.shouldNotBeNull()
     }
 
     @Test

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementExtsSpec.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.psi.java
+
+import com.intellij.psi.PsiStatement
+import com.intellij.psi.PsiTypeElement
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.spine.tools.psi.java.PsiTest.Companion.parse
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("`PsiElementExts` should")
+internal class PsiElementExtsSpec : PsiTest() {
+
+    @Nested
+    inner class
+    `look for elements by text` {
+
+        @Test
+        fun `returning 'null' when not found`() {
+            psiClass.findFirstByText("tableAndChair") shouldBe null
+        }
+
+        @Test
+        fun `throwing when not found`() {
+            assertThrows<IllegalArgumentException> {
+                psiClass.getFirstByText("tableAndChair")
+            }
+        }
+
+        @Test
+        fun `returning element which is a direct child`() {
+            val buildPartial = psiClass.method("buildPartial")
+            val returnedType = buildPartial.findFirstByText("io.spine.base.FieldPath")
+            returnedType.shouldBeInstanceOf<PsiTypeElement>()
+        }
+
+        @Test
+        fun `returning element which is an indirect child`() {
+            val buildPartial = psiClass.method("buildPartial")
+            val statement = buildPartial.findFirstByText("buildPartial0(result);")
+            statement.shouldBeInstanceOf<PsiStatement>()
+        }
+
+        @Test
+        fun `satisfying both 'startsWith' and 'contains' criteria`() {
+            val buildPartial = psiClass.methodWithSignature(MERGE_FROM_SIGNATURE)
+            val ifStatement = buildPartial.findFirstByText("if (", "parseUnknownField")
+            ifStatement.shouldNotBeNull()
+            ifStatement.text shouldBe """
+              if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                done = true; // was an endgroup tag
+              }
+            """.trim()
+        }
+    }
+}
+
+private val psiFile = parse("FieldPath.java")
+private val psiClass = psiFile.topLevelClass.nested("Builder")
+
+private val MERGE_FROM_SIGNATURE = """
+        public Builder mergeFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+""".trimIndent()

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementExtsSpec.kt
@@ -51,14 +51,14 @@ internal class PsiElementExtsSpec : PsiTest() {
         }
 
         @Test
-        fun `returning element which is a direct child`() {
+        fun `returning an element which is a direct child`() {
             val buildPartial = psiClass.method("buildPartial")
             val returnedType = buildPartial.findFirstByText("io.spine.base.FieldPath")
             returnedType.shouldBeInstanceOf<PsiTypeElement>()
         }
 
         @Test
-        fun `returning element which is an indirect child`() {
+        fun `returning an element which is an indirect child`() {
             val buildPartial = psiClass.method("buildPartial")
             val statement = buildPartial.findFirstByText("buildPartial0(result);")
             statement.shouldBeInstanceOf<PsiStatement>()

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiElementExtsSpec.kt
@@ -31,29 +31,23 @@ import com.intellij.psi.PsiTypeElement
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import io.spine.tools.psi.java.PsiTest.Companion.parse
+import io.spine.tools.psi.MERGE_FROM_SIGNATURE
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 @DisplayName("`PsiElementExts` should")
 internal class PsiElementExtsSpec : PsiTest() {
 
-    @Nested
-    inner class
+    @Nested inner class
     `look for elements by text` {
+
+        private val psiFile = parse("FieldPath.java")
+        private val psiClass = psiFile.topLevelClass.nested("Builder")
 
         @Test
         fun `returning 'null' when not found`() {
             psiClass.findFirstByText("tableAndChair") shouldBe null
-        }
-
-        @Test
-        fun `throwing when not found`() {
-            assertThrows<IllegalArgumentException> {
-                psiClass.getFirstByText("tableAndChair")
-            }
         }
 
         @Test
@@ -83,12 +77,3 @@ internal class PsiElementExtsSpec : PsiTest() {
         }
     }
 }
-
-private val psiFile = parse("FieldPath.java")
-private val psiClass = psiFile.topLevelClass.nested("Builder")
-
-private val MERGE_FROM_SIGNATURE = """
-        public Builder mergeFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-""".trimIndent()

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiStatementsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiStatementsSpec.kt
@@ -39,8 +39,8 @@ internal class PsiStatementsSpec : PsiTest() {
     fun `be created from a code block`() {
         val codeBlock = elementFactory.createCodeBlockFromText("{$STATEMENTS_TEXT}", null)
         val statements = PsiStatements(codeBlock)
-        statements.firstChild.text shouldBe STATEMENT_LINES.first().trim()
-        statements.lastChild.text shouldBe STATEMENT_LINES.last().trim()
+        statements.firstChild.text shouldBe STATEMENT_LINES.first()
+        statements.lastChild.text shouldBe STATEMENT_LINES.last()
     }
 
     @Test

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiStatementsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/java/PsiStatementsSpec.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.psi.java
+
+import io.kotest.matchers.shouldBe
+import io.spine.tools.psi.java.Environment.elementFactory
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`PsiStatements` should")
+internal class PsiStatementsSpec : PsiTest() {
+
+    @Test
+    fun `be created from a code block`() {
+        val codeBlock = elementFactory.createCodeBlockFromText("{$STATEMENTS_TEXT}", null)
+        val statements = PsiStatements(codeBlock)
+        statements.firstChild.text shouldBe STATEMENT_LINES.first().trim()
+        statements.lastChild.text shouldBe STATEMENT_LINES.last().trim()
+    }
+
+    @Test
+    fun `be created from text using the factory`() {
+        val statements = elementFactory.createStatementsFromText(STATEMENTS_TEXT, null)
+        statements.firstChild.text shouldBe STATEMENT_LINES.first()
+        statements.lastChild.text shouldBe STATEMENT_LINES.last()
+    }
+
+    @Nested inner class
+    `provide shortcuts for 'PsiElement' to` {
+
+        private val variableStatement = "var value = 0;"
+        private val returnStatement = "return null;"
+        private val method = elementFactory.createMethodFromText("""
+            public Bar foo() {
+                $variableStatement
+                $returnStatement
+            }
+        """.trimIndent(), null)
+        private val methodBody = method.body!!
+
+        @Test
+        fun `add statements`() {
+            val statements = elementFactory.createStatementsFromText(STATEMENTS_TEXT, null)
+            methodBody.add(statements)
+            val expected = listOf(variableStatement, returnStatement) + STATEMENT_LINES
+            methodBody.statements.map { it.text } shouldBe expected
+        }
+
+        @Test
+        fun `add statements after the given element`() {
+            val statements = elementFactory.createStatementsFromText(STATEMENTS_TEXT, null)
+            val variable = methodBody.getFirstByText(variableStatement)
+            methodBody.addAfter(statements, variable)
+            val expected = listOf(variableStatement) + STATEMENT_LINES + listOf(returnStatement)
+            methodBody.statements.map { it.text } shouldBe expected
+        }
+
+        @Test
+        fun `add statements before the given element`() {
+            val statements = elementFactory.createStatementsFromText(STATEMENTS_TEXT, null)
+            val variable = methodBody.getFirstByText(variableStatement)
+            methodBody.addBefore(statements, variable)
+            val expected = STATEMENT_LINES + listOf(variableStatement, returnStatement)
+            methodBody.statements.map { it.text } shouldBe expected
+        }
+    }
+}
+
+private val STATEMENTS_TEXT =
+    """
+    java.util.Optional<io.spine.validate.ValidationError> error = result.validate();
+    var violations = error.get().getConstraintViolationList();
+    throw new io.spine.validate.ValidationException(violations);
+    """.trim()
+
+private val STATEMENT_LINES = STATEMENTS_TEXT.lines()
+    .map { it.trim() }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.241")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.242")


### PR DESCRIPTION
This PR moves PSI extensions from `validation` library, covering them with tests.