### PR TITLE
More on extensions

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.301`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.302`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -493,12 +493,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 16:09:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 14:46:40 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.301`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.302`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -1763,12 +1763,12 @@ This report was generated on **Fri Mar 21 16:09:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 16:09:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 14:46:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.301`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.302`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2562,12 +2562,12 @@ This report was generated on **Fri Mar 21 16:09:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 16:09:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 14:46:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.301`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.302`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -3476,12 +3476,12 @@ This report was generated on **Fri Mar 21 16:09:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 16:09:37 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 14:46:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.301`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.302`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4505,12 +4505,12 @@ This report was generated on **Fri Mar 21 16:09:37 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 16:09:38 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 14:46:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.301`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.302`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -6236,12 +6236,12 @@ This report was generated on **Fri Mar 21 16:09:38 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 16:09:38 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 14:46:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.301`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.302`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7060,4 +7060,4 @@ This report was generated on **Fri Mar 21 16:09:38 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 21 16:09:38 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Mar 22 14:46:43 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/protobuf/SourceSetExts.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/protobuf/SourceSetExts.kt
@@ -27,6 +27,7 @@
 package io.spine.tools.gradle.protobuf
 
 import io.spine.tools.gradle.protobuf.ProtobufDependencies.sourceSetExtensionName
+import io.spine.tools.gradle.task.findKotlinDirectorySet
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.SourceSet
 
@@ -37,7 +38,7 @@ import org.gradle.api.tasks.SourceSet
  *         at least one file. Otherwise, false.
  */
 public fun SourceSet.containsProtoFiles(): Boolean {
-    val protoDirectorySet = protoDirectorySet()
+    val protoDirectorySet = findProtoDirectorySet()
         ?: return false // no `proto` extension at all.
     val isEmpty = protoDirectorySet.files.isEmpty()
     return !isEmpty
@@ -50,7 +51,19 @@ public fun SourceSet.containsProtoFiles(): Boolean {
  *         by the Protobuf Gradle Plugin.
  * @see ProtobufDependencies.sourceSetExtensionName
  */
-public fun SourceSet.protoDirectorySet(): SourceDirectorySet? =
+@Deprecated(
+    message = "Use `findProtoDirectorySet()` instead.", ReplaceWith("findProtoDirectorySet()")
+)
+public fun SourceSet.protoDirectorySet(): SourceDirectorySet? = findProtoDirectorySet()
+
+/**
+ * Obtains a [SourceDirectorySet] containing `.proto` files in this [SourceSet].
+ *
+ * @return the directory set or `null`, if there is no `proto` extension added to this `SourceSet`
+ *         by the Protobuf Gradle Plugin.
+ * @see ProtobufDependencies.sourceSetExtensionName
+ */
+public fun SourceSet.findProtoDirectorySet(): SourceDirectorySet? =
     extensions.getByName(sourceSetExtensionName)
         .let { ext -> ext as? SourceDirectorySet }
 
@@ -59,5 +72,11 @@ public fun SourceSet.protoDirectorySet(): SourceDirectorySet? =
  *
  * @return the directory set or `null` if there is no `kotlin` extension in this source set.
  */
-public fun SourceSet.kotlinDirectorySet(): SourceDirectorySet? =
-    extensions.findByName("kotlin") as SourceDirectorySet?
+@Deprecated(
+    message = "Use `findKotlinDirectorySet()` instead.",
+    ReplaceWith(
+        "findKotlinDirectorySet()",
+        imports = arrayOf("io.spine.tools.gradle.task.findKotlinDirectorySet")
+    )
+)
+public fun SourceSet.kotlinDirectorySet(): SourceDirectorySet? = findKotlinDirectorySet()

--- a/plugin-base/src/main/kotlin/io/spine/tools/gradle/task/SourceSetExts.kt
+++ b/plugin-base/src/main/kotlin/io/spine/tools/gradle/task/SourceSetExts.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle.task
+
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.tasks.SourceSet
+import io.spine.tools.code.Kotlin
+
+/**
+ * Obtains the Kotlin source directory of this source set.
+ *
+ * @return the directory set or `null` if there is no `kotlin` extension in this source set.
+ */
+public fun SourceSet.findKotlinDirectorySet(): SourceDirectorySet? =
+    extensions.findByName(Kotlin.name.lowercase()) as SourceDirectorySet?

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.301</version>
+<version>2.0.0-SNAPSHOT.302</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.301")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.302")


### PR DESCRIPTION
This PR applies the `findXxx()` convention to the existing extension functions that return nullable types. Also, the `SourceSet.findKotlinDirectorySet()` extension function was introduced in the `task` package, deprecating the one which does the same but wrongly placed under the `protobuf` package.
