### PR TITLE
Avoid duplicated repositories when arranging custom module publication

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
@@ -46,9 +46,8 @@ internal object GitHubPackages {
         return Repository(
             name = "GitHub-Packages",
             releases = url,
-            snapshots = url,
-            credentialValues = { project -> project.credentialsWithToken(githubActor) }
-        )
+            snapshots = url
+        ) { project -> project.credentialsWithToken(githubActor) }
     }
 
     private fun actor(): String {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
@@ -78,10 +78,11 @@ internal val Project.spinePublishing: SpinePublishing
     }
 
 /**
- * Tells if this project has custom publishing.
+ * Tells if this project has custom publishing by checking if it is listed
+ * among [SpinePublishing.modulesWithCustomPublishing] in the root project.
  */
 internal val Project.hasCustomPublishing: Boolean
-    get() = spinePublishing.modulesWithCustomPublishing.contains(name)
+    get() = rootProject.spinePublishing.modulesWithCustomPublishing.contains(name)
 
 private const val PUBLISH_TASK = "publish"
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
@@ -78,11 +78,17 @@ internal val Project.spinePublishing: SpinePublishing
     }
 
 /**
- * Tells if this project has custom publishing by checking if it is listed
- * among [SpinePublishing.modulesWithCustomPublishing] in the root project.
+ * Tells if this project has custom publishing.
+ *
+ * For a multi-module project this is checked by presence of this project
+ * in the list of [SpinePublishing.modulesWithCustomPublishing] of the root project.
+ *
+ * In a single-module project, the value of the [SpinePublishing.customPublishing]
+ * property is returned.
  */
 internal val Project.hasCustomPublishing: Boolean
     get() = rootProject.spinePublishing.modulesWithCustomPublishing.contains(name)
+            || spinePublishing.customPublishing
 
 private const val PUBLISH_TASK = "publish"
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
@@ -196,18 +196,27 @@ open class SpinePublishing(private val project: Project) {
     var modules: Set<String> = emptySet()
 
     /**
-     * Controls whether the published module needs standard publications.
-     *
-     * If `true`, the module should configure publications on its own.
-     * Otherwise, the extension will configure standard [ones][StandardJavaPublicationHandler].
-     *
-     * This property is analogue of [modulesWithCustomPublishing] for projects,
-     * for which [spinePublishing] is configured individually.
-     *
-     * Setting of this property and having a non-empty [modules] will lead
-     * to an exception.
+     * Controls whether the [module][project] needs standard publications.
      *
      * Default value is `false`.
+     *
+     * In a single module [project], settings this property to `true` it tells
+     * that the project configures the publication in a specific way and
+     * [CustomPublicationHandler] should be used.
+     * Otherwise, the extension will configure the
+     * [standard publication][StandardJavaPublicationHandler].
+     *
+     * This property is an analogue of [modulesWithCustomPublishing] in
+     * [multi-module][Project.getSubprojects] projects,
+     * for which [spinePublishing] is configured individually.
+     *
+     * Setting of this property to `true` and having a non-empty [modules] property
+     * in the project to which the extension is applied will lead to [IllegalStateException].
+     *
+     * Settings this property to `true` in a subproject serves only the documentation purposes.
+     * This subproject still must be listed in the [modulesWithCustomPublishing] property in
+     * the extension of the [rootProject][Project.getRootProject], so that its publication
+     * can be configured in a specific way.
      */
     var customPublishing = false
 
@@ -270,7 +279,7 @@ open class SpinePublishing(private val project: Project) {
      * }
      * ```
      *
-     * The resulting artifact is available under "proto" classifier.
+     * The resulting artifact is available under the "proto" classifier.
      * For example, in Gradle 7+, one could depend on it like this:
      *
      * ```

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/StandardJavaPublicationHandler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/StandardJavaPublicationHandler.kt
@@ -60,7 +60,8 @@ internal class StandardJavaPublicationHandler(
 ) : PublicationHandler(project, destinations) {
 
     /**
-     * Creates a new "mavenJava" [org.gradle.api.publish.maven.MavenPublication] in the given project.
+     * Creates a new `"mavenJava"` [MavenPublication][org.gradle.api.publish.maven.MavenPublication]
+     * in the [project] associated with this publication handler.
      */
     override fun handlePublications() {
         val jars = project.artifacts(jarFlags)

--- a/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repository.kt
@@ -116,6 +116,21 @@ data class Repository(
         val password = properties.getProperty("user.password")
         return Credentials(username, password)
     }
+    
+    override fun equals(other: Any?): Boolean = when {
+        this === other -> true
+        other !is Repository -> false
+        else -> name == other.name &&
+           releases == other.releases &&
+           snapshots == other.snapshots
+}
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + releases.hashCode()
+        result = 31 * result + snapshots.hashCode()
+        return result
+    }
 
     override fun toString(): String {
         return name

--- a/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repository.kt
@@ -32,16 +32,29 @@ import org.gradle.api.Project
 
 /**
  * A Maven repository.
+ *
+ * @param name The human-readable name which is also used in the publishing task names
+ *   for identifying the target repository.
+ *   The name must match the [regex].
+ * @param releases The URL for publishing release versions of artifacts.
+ * @param snapshots The URL for publishing [snapshot][io.spine.gradle.isSnapshot] versions.
+ * @param credentialsFile The path to the file which contains the credentials for the registry.
+ * @param credentialValues The function to obtain an instance of [Credentials] from
+ *   a Gradle [Project], if [credentialsFile] is not specified.
  */
 data class Repository(
+    private val name: String,
     private val releases: String,
     private val snapshots: String,
     private val credentialsFile: String? = null,
-    private val credentialValues: ((Project) -> Credentials?)? = null,
-    private val name: String
+    private val credentialValues: ((Project) -> Credentials?)? = null
 ) {
-    init {
+
+    companion object {
         val regex = Regex("[A-Za-z0-9_\\-.]+")
+    }
+
+    init {
         require(regex.matches(name)) {
             "The repository name `$name` does not match the regex `$regex`."
         }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-gradle-plugin-api:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:spine-gradle-plugin-api:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -879,12 +879,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:06 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:48 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:spine-gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1267,12 +1267,12 @@ This report was generated on **Thu Apr 24 16:55:06 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:06 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:48 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-gradle-root-plugin:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:spine-gradle-root-plugin:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.0.2.
@@ -2060,12 +2060,12 @@ This report was generated on **Thu Apr 24 16:55:06 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:06 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2574,12 +2574,12 @@ This report was generated on **Thu Apr 24 16:55:06 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:06 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3860,12 +3860,12 @@ This report was generated on **Thu Apr 24 16:55:06 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:07 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-api:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:spine-plugin-api:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.0.2.
@@ -4601,12 +4601,12 @@ This report was generated on **Thu Apr 24 16:55:07 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:07 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5470,12 +5470,12 @@ This report was generated on **Thu Apr 24 16:55:07 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:07 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -6442,12 +6442,12 @@ This report was generated on **Thu Apr 24 16:55:07 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:08 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -7541,12 +7541,12 @@ This report was generated on **Thu Apr 24 16:55:08 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:08 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -9370,12 +9370,12 @@ This report was generated on **Thu Apr 24 16:55:08 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:08 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10260,4 +10260,4 @@ This report was generated on **Thu Apr 24 16:55:08 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 16:55:08 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:11:51 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -879,7 +879,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:48 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1267,7 +1267,7 @@ This report was generated on **Thu Apr 24 20:11:48 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:48 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2060,7 +2060,7 @@ This report was generated on **Thu Apr 24 20:11:48 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2574,7 +2574,7 @@ This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3860,7 +3860,7 @@ This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:33 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4601,7 +4601,7 @@ This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:33 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5470,7 +5470,7 @@ This report was generated on **Thu Apr 24 20:11:49 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:33 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6442,7 +6442,7 @@ This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:33 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7541,7 +7541,7 @@ This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:34 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9370,7 +9370,7 @@ This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:34 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10260,4 +10260,4 @@ This report was generated on **Thu Apr 24 20:11:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 24 20:11:51 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 24 20:24:34 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.307</version>
+<version>2.0.0-SNAPSHOT.308</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.307")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.308")


### PR DESCRIPTION
This PR continues the efforts of fighting with the failed publishing jobs. Hopefully, we nailed it this time. 

The publication code under `buildSrc` was traced agains the local publishing and it was discovered that the adding destination directories for a publication that we called on `Project.afterEvaluate` was executed twice. The reason for calling the actions put under `afterEvaluate` more than once is unknown. Also, there is not guaranty that this behaviour is stable from version to version of Gradle, so we took the approach of remembering the state under the `synchronized` block.

The duplication of target repositories always worked this way. It's only recently that we started experiencing this under the `tool-base` repository because the fat JAR of IntelliJ IDEA platform is a big file, which failed the repeated creation of concurrently running tasks with the different names (because of the duplicated destinations), but with the same target file name.

### Notable changes
 * The `Project.hasCustomPublication` now checks for the presence of the project in the extension of the root project, which is a most usual case because most of our projects are multi-module. For a single-module project the property returns  the value of `SpinePublishing.customPublishing` property.
 * The properties passed to the `Repository` constructor were re-arranged to put the `name` first. Also the `name` is checked to match the requirements of a repository name so that it can be used as a part of the publishing task.
 * `Repository.equals()` and `hashCode()` were added in a simplified way which takes into account only string properties.

