### PR TITLE
Add `AGENTS.md` guidelines

### DIFF
--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -7,6 +7,7 @@
       <w>bytebuffer</w>
       <w>callees</w>
       <w>closeables</w>
+      <w>kotest</w>
       <w>cqrs</w>
       <w>dartdocs</w>
       <w>dataset</w>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,19 +15,24 @@
 9. [Safety Rules](#safety-rules)
 10. [Interaction Tips](#interaction-tips)
 
-## 🧠 The purpose of this document
+## 🧠 Purpose
 
-This file defines how LLM agents (e.g. **ChatGPT** and **Codex**) should
-**interact with the codebase**, **generate content**, and **assist in development workflows**
-for this project, which is based on **Kotlin** and **Java**.
+This document explains how to use **ChatGPT** and **Codex** effectively in this Kotlin/Java project.
 
-It outlines conventions, expectations, and usage goals to ensure
-**productive, safe, and consistent collaboration**.
-                                                            
+It outlines:
+
+- Agent responsibilities (who does what).
+- Coding and architectural guidelines agents must follow.
+- Instructions for creating and testing agent-generated outputs.
+
+Whether you are a developer, tester, or contributor, this guide will help you collaborate
+with AI to maintain a high-quality codebase.
+
 ### Terminology
-- **LLM**: Use when referring to the general technology.
-- **Agents**: Refers to ChatGPT, Codex, or any LLM.
- - Specific names (**ChatGPT** / **Codex** / **Claude**): Only when functionality diverges.
+- **LLM**: Refers to the general category of language models (e.g., ChatGPT, Codex, Claude).
+- **Agents**: A broader term for LLMs collaborating on this project. 
+- Use specific names (**ChatGPT**, **Codex**) when they excel at different tasks 
+  (e.g., scaffolding versus explanation).
 
 ---
 
@@ -42,44 +47,53 @@ It outlines conventions, expectations, and usage goals to ensure
 
 ---
 
-## 🤖 Agent roles
+## 🤖 Agent responsibilities
 
-### 🗨️ Helping with understanding and improvements
+| Task/Feature                      | Primary Agent | Supporting Agent | Notes                                      |
+|-----------------------------------|---------------|------------------|--------------------------------------------|
+| Writing Documentation (like KDoc) | ChatGPT       | Codex            | Use for readable, structured docs.         |
+| Explaining APIs/Architecture      | ChatGPT       | -                | Great for clarity in team workflows.       |
+| Code Generation (e.g., tests)     | Codex         | ChatGPT          | Codex produces quick scaffolding.          |
+| Code Refactoring Suggestions      | ChatGPT       | Codex            | Use ChatGPT for design-level improvements. |
+| Completing Functions/Classes      | Codex         | -                | Codex is better for direct completions.    |
+| Debugging/Test Suggestions        | ChatGPT       | Codex            | ChatGPT suggests missing scenarios.        |
 
-- Explain code, APIs, and architecture
-- Refactor or simplify logic
-- Help with design decisions and trade-offs
-- Generate documentation (KDoc, Markdown)
-- Suggest tests and edge cases
-- Summarize diffs or changes
-- Generate Gradle configurations
-- Assist with naming and conceptual clarity
 
-### 🔧 Code completion and code generation
+### Tagging pull request messages
 
-- Complete functions, classes, and tests
-- Generate Kotlin idioms (e.g., extension functions, DSLs)
-- Follow patterns from nearby code
-- Generate test scaffolds and fixtures
-- Fill in `when` branches, sealed class hierarchies, etc.
-
+While crafting GitHub PR messages, tag agent roles as needed:
+```text
+feat(chatgpt): Updated README with clearer KDoc examples
+fix(codex): Completed missing `when` branches in tests
+```
+##### Why tag pull requests?
+Tagging PRs helps the team:
+  - Track which agent contributed to specific changes.
+  - Understand whether a PR needs extra human review based on the agent’s role.
+  - Make decisions about multi-agent collaboration in reviews.
 ---
 
 ## 🧾 Coding guidelines for Agents
 
 ### ✅ Preferred
 
-1. Use **idiomatic Kotlin**, including:
-    - Extension functions
-    - `when` expressions
-    - Smart casts
-    - Data classes
-    - Sealed classes
+1. Kotlin idioms are **preferred** over Java-style approaches, including:
+   - Extension functions
+   - `when` expressions
+   - Smart casts
+   - Data classes
+   - Sealed classes
+
 2. Immutable data structures. 
+
 3. Apply **Java interop** only when needed (e.g., using annotations or legacy libraries).
+
 4. Use **Kotlin DSL** when modifying or generating Gradle files.
+
 5. Generate code that **compiles cleanly** and **passes static analysis**.
+
 6. Respect **existing architecture**, naming conventions, and project structure.
+
 7. Use `@file:JvmName`, `@JvmStatic`, etc., where appropriate.
 
 ### ❌ Avoid
@@ -106,8 +120,13 @@ It outlines conventions, expectations, and usage goals to ensure
 ### Naming convention for variables
 - Prefer simple nouns over composite nouns. E.g., `user` is better than `userAccount`.
 
+### Safety Rules Checklist
+- ✅ Ensure all generated code compiles and passes static analysis.
+- ❌ Avoid unnecessary reflection or unsafe code (e.g., `!!` in Kotlin).
+- ✅ Do not auto-update external dependencies unless explicitly allowed.
+
 ---
-## Incrementing a patch version for each pull request
+## Version policy
 
 ### We use semver
 The version number of the project is kept in the file named `version.gradle.kts` which resides
@@ -116,18 +135,33 @@ in the root of the project.
 The version numbers in these files follow the conventions of
 [Semantic Versioning 2.0.0](https://semver.org/).
 
-### Incrementing the version
-When creating a pull request, the version **must** be updated by incrementing
-the **last component** of the version number by one.
-For example, the version `"2.0.0-SNAPSHOT.42"` should become `"2.0.0-SNAPSHOT.43"`   
+### Increment a patch version for each pull request
 
-If the last component has leading zeroes, keep the padding of zeroes so that the width of
-the last component stays the same. For example, the version `"2.0.0-SNAPSHOT.009"` should become
-`"2.0.0-SNAPSHOT.010"`.
+1. Open the `version.gradle.kts` file in the root directory.
 
-### What if?
-Not incrementing the version will result in **build failure** because we have a GitHub workflow
-which checks for the increment.
+2. Increment the **last number** of the version. Retain zero-padding if applicable:
+    - Example: `"2.0.0-SNAPSHOT.009"` → `"2.0.0-SNAPSHOT.010"`
+
+3. Commit the `version.gradle.kts` file in a separate commit with the comment of the following
+   format:
+    ```text
+    Bump version -> `$newVersion`
+    ```
+    where `$newVersion` is the version number without quotes. For example:
+    ```text
+    Bump version -> `2.0.0-SNAPSHOT.010`
+    ```
+4. Run `./gradlew clean build`
+
+5. Commit updated files `pom.xml` and `dependencies.md` with the following comment: 
+   ```text
+   Update dependency reports.
+   ```
+
+### What happens if you forget to increment the version?
+
+Build failure! A GitHub workflow checks for correct version increments.
+
 
 ### Resolving conflicts in `version.gradle.kts`
 A branch conflict over the version number should be resolved as described below.
@@ -139,16 +173,29 @@ A branch conflict over the version number should be resolved as described below.
 
 ## Running builds
 
-1. When modifying code, run `./gradlew build` before committing.
-2. If Protobuf (`.proto`) files are modified **always** run `./gradlew clean build`.
-3. Documentation-only changes do not require running tests.
+1. When modifying code, run:
+   ```bash
+   ./gradlew build
+   ```
+   
+2. If Protobuf (`.proto`) files are modified run:
+   ```bash
+   ./gradlew clean build
+   ````
 
+3. Documentation-only changes run:
+   ```bash
+   ./gradlew dokka
+   ```
+   Documentation-only changes do not require running tests!
 ---
 
 ## 📁 Project structure expectations
 
 ```yaml
-<module1>
+.github
+buildSrc/
+<module-1>
   src/
   ├── main/
   │ ├── kotlin/ # Kotlin source files
@@ -156,13 +203,13 @@ A branch conflict over the version number should be resolved as described below.
   ├── test/
   │ └── kotlin/ # Unit and integration tests
   build.gradle.kts # Kotlin-based build configuration
-<module2>
-<module3>
+<module-2>
+<module-3>
 build.gradle.kts # Kotlin-based build configuration
 settings.gradle.kts # Project structure and settings
 README.md # Project overview
 AGENTS.md # LLM agent instructions (this file)
-
+version.gradle.kts # Declares the project version. 
 ```
 ---
 
@@ -175,22 +222,23 @@ AGENTS.md # LLM agent instructions (this file)
 
 ---
 
-## 🧪 Testing responsibilities
+## 🧪 Testing
 
-- Generate tests for:
-    - Public functions
-    - Edge cases
-    - Extension functions and DSLs
+### Guidelines
+- Do not use mocks, use stubs.
+- Prefer [Kotest assertions](https://kotest.io/docs/assertions/assertions.html) over
+  assertions from JUnit or Google Truth.
 
-- Suggest:
-    - Test coverage improvements
-    - Performance testing
-    - Property-based testing
+### Responsibilities
 
-### Testing guidelines
- - Do not use mocks, use stubs.
- - Prefer [Kotest assertions](https://kotest.io/docs/assertions/assertions.html) over
-   assertions from JUnit or Google Truth.
+#### Codex
+- Generate unit tests for APIs (handles edge cases/scenarios).
+- Supply scaffolds for typical Kotlin patterns (`when`, sealed classes).
+
+#### ChatGPT
+- Suggest test coverage improvements.
+- Propose property-based testing or rare edge case scenarios.
+
 ---
 
 ## 🚨 Safety rules for Agents
@@ -202,7 +250,7 @@ AGENTS.md # LLM agent instructions (this file)
 
 ---
 
-## 💬 Interaction tips
+## 💬 Interaction tips – key to effective collaboration!
 
 - Human programmers may use inline comments to guide agents:
   ```kotlin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,31 @@
 > Guidance for Large Language Model (LLM) Agents (ChatGPT & Codex) collaborating on this project.
 
 ---
+## Table of Contents
+1. [The purpose of this document](#the-purpose-of-this-document)
+2. [Project overview](#project-overview)
+3. [Agent roles](#agent-roles)
+4. [Coding guidelines](#coding-guidelines)
+5. [Running builds](#running-builds)
+6. [Incrementing a version](#incrementing-a-patch-version)
+7. [Documentation Tasks](#documentation-tasks)
+8. [Testing Responsibilities](#testing-responsibilities)
+9. [Safety Rules](#safety-rules)
+10. [Interaction Tips](#interaction-tips)
 
 ## 🧠 The purpose of this document
 
-This file defines how LLM agents (e.g. **ChatGPT** and **Codex**) should **interact with the codebase**, **generate content**, and **assist in development workflows** for this project, which is based on **Kotlin** and **Java**. It outlines conventions, expectations, and usage goals to ensure **productive, safe, and consistent collaboration**.
+This file defines how LLM agents (e.g. **ChatGPT** and **Codex**) should
+**interact with the codebase**, **generate content**, and **assist in development workflows**
+for this project, which is based on **Kotlin** and **Java**.
+
+It outlines conventions, expectations, and usage goals to ensure
+**productive, safe, and consistent collaboration**.
+                                                            
+### Terminology
+- **LLM**: Use when referring to the general technology.
+- **Agents**: Refers to ChatGPT, Codex, or any LLM.
+ - Specific names (**ChatGPT** / **Codex** / **Claude**): Only when functionality diverges.
 
 ---
 
@@ -17,7 +38,7 @@ This file defines how LLM agents (e.g. **ChatGPT** and **Codex**) should **inter
 - **Architecture**: Event-driven Domain-Driven Design (DDD).
 - **Testing**: JUnit 5
 - **Style**: Kotlin idiomatic code preferred over Java-style code
-- **Tools Used**: KotlinPoet, KSP, Gradle plugins, IntelliJ IDEA
+- **Tools Used**: Gradle plugins, IntelliJ IDEA Platform, KSP, KotlinPoet 
 
 ---
 
@@ -34,13 +55,13 @@ This file defines how LLM agents (e.g. **ChatGPT** and **Codex**) should **inter
 - Generate Gradle configurations
 - Assist with naming and conceptual clarity
 
-### 🔧 Codex (code completion/generation)
+### 🔧 Codex — code completion and code generation
 
 - Complete functions, classes, and tests
 - Generate Kotlin idioms (e.g., extension functions, DSLs)
 - Follow patterns from nearby code
 - Generate test scaffolds and fixtures
-- Fill in `when` branches, sealed class hierarchies, etc
+- Fill in `when` branches, sealed class hierarchies, etc.
 
 ---
 
@@ -48,17 +69,17 @@ This file defines how LLM agents (e.g. **ChatGPT** and **Codex**) should **inter
 
 ### ✅ Preferred
 
-- Use **idiomatic Kotlin**, including:
+1. Use **idiomatic Kotlin**, including:
     - Extension functions
     - `when` expressions
     - Smart casts
     - Data classes
     - Sealed classes
-- Apply **Java interop** only when needed (e.g., using annotations or legacy libraries)
-- Use **Kotlin DSL** when modifying or generating Gradle files
-- Generate code that **compiles cleanly** and **passes static analysis**
-- Respect **existing architecture**, naming conventions, and project structure
-- Use `@file:JvmName`, `@JvmStatic`, etc., where appropriate.
+2. Apply **Java interop** only when needed (e.g., using annotations or legacy libraries)
+3. Use **Kotlin DSL** when modifying or generating Gradle files
+4. Generate code that **compiles cleanly** and **passes static analysis**
+5. Respect **existing architecture**, naming conventions, and project structure
+6. Use `@file:JvmName`, `@JvmStatic`, etc., where appropriate.
 
 ### ❌ Avoid
 
@@ -69,34 +90,56 @@ This file defines how LLM agents (e.g. **ChatGPT** and **Codex**) should **inter
 - Overuse of reflection unless requested
 
 ### General guidance
+- Adhere to the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki)
+  for coding style and contribution procedures. 
 
+- The conventions on the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki)
+  page and other pages in this Wiki area **take precedence over** standard Kotlin or
+  Java conventions.
+ 
 - Write clear, incremental commits with descriptive messages.
 - Include automated tests for any code change that alters functionality.
 - Keep pull requests focused and small.
-- Adhere to the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki) for coding style and
-  contribution procedures.
 
 ### Naming convention for variables
 - Prefer simple nouns over composite nouns. E.g., `user` is better than `userAccount`.
 
 ---
-
-## Running builds
-
-- When modifying code, run `./gradlew build` before committing.
-- If Protobuf (`.proto`) files are modified **always** run `./gradlew clean build`.
-- Documentation-only changes do not require running tests.
-
----
-
 ## Incrementing a patch version for each pull request
 
-When creating a pull request, update the `version.gradle.kts` file in the root of a project
-by incrementing the last component of the version number by 1.
+### We use semver
+The version number of the project is kept in the file named `version.gradle.kts` which resides
+in the root of the project.
+
+The version numbers in these files follow the conventions of
+[Semantic Versioning 2.0.0](https://semver.org/).
+
+### Incrementing the version
+When creating a pull request, the version **must** be updated by incrementing
+the **last component** of the version number by one.
+For example, the version `"2.0.0-SNAPSHOT.42"` should become `"2.0.0-SNAPSHOT.43"`   
 
 If the last component has leading zeroes, keep the padding of zeroes so that the width of
 the last component stays the same. For example, the version `"2.0.0-SNAPSHOT.009"` should become
 `"2.0.0-SNAPSHOT.010"`.
+
+### What if?
+Not incrementing the version will result in **build failure** because we have a GitHub workflow
+which checks for the increment.
+
+### Resolving conflicts in `version.gradle.kts`
+A branch conflict over the version number should be resolved as described below.
+ * If a merged branch has a number which is less than that of the current branch, the version of
+   the current branch stays.
+ * If the merged branch has the number which is greater or equal to that of the current branch,
+   the number should be increased by one.
+---
+
+## Running builds
+
+1. When modifying code, run `./gradlew build` before committing.
+2. If Protobuf (`.proto`) files are modified **always** run `./gradlew clean build`.
+3. Documentation-only changes do not require running tests.
 
 ---
 
@@ -121,7 +164,7 @@ AGENTS.md # LLM agent instructions (this file)
 ```
 ---
 
-## 📄 Documentation Tasks for ChatGPT
+## 📄 Documentation tasks for ChatGPT
 
 - Generate and update **KDoc** for public APIs
 - Draft/update **README.md**, **CONTRIBUTING.md**
@@ -131,7 +174,7 @@ AGENTS.md # LLM agent instructions (this file)
 
 ---
 
-## 🧪 Testing Responsibilities
+## 🧪 Testing responsibilities
 
 - **Codex** should generate tests for:
     - Public functions
@@ -146,27 +189,33 @@ AGENTS.md # LLM agent instructions (this file)
 
 ---
 
-## 🚨 Safety Rules for Agents
+## 🚨 Safety rules for Agents
 
-- Do **not** auto-update external dependencies without explicit request
-- Do **not** inject analytics or telemetry code
-- Flag any usage of unsafe constructs (e.g., reflection, I/O on main thread)
-- Avoid generating blocking calls inside coroutines
+- Do **not** auto-update external dependencies without explicit request.
+- Do **not** inject analytics or telemetry code.
+- Flag any usage of unsafe constructs (e.g., reflection, I/O on the main thread).
+- Avoid generating blocking calls inside coroutines.
 
 ---
 
 ## 💬 Interaction tips
 
-- Use comments like `// ChatGPT: explain this logic` or `// Codex: complete this function`
-- Use Git commit messages like:
-
+- Human programmers may use inline comments to guide agents:
+  ```kotlin
+    // ChatGPT: Suggest a refactor for better readability.
+    // Codex: Complete the missing branches in this `when` block.
+    // ChatGPT: explain this logic.
+    // Codex: complete this function.
+   ```
+- Agents, should ensure pull request messages are concise and descriptive:
   ```text
   feat(chatgpt): suggested DSL refactoring for query handlers  
-  fix(codex): completed missing case in sealed class hierarchy  
-
+  fix(codex): completed missing case in sealed class hierarchy
   ```
-- Encourage `// TODO:` or `// FIXME:` comments to be clarified by ChatGPT
+- Encourage `// TODO:` or `// FIXME:` comments to be clarified by ChatGPT.
 
+- When agents or humans add TODO comments, they **must** follow the format described on
+  the [dedicated page](https://github.com/SpineEventEngine/documentation/wiki/TODO-comments).
 ---
 
 ## 🧭 LLM Goals

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ with AI to maintain a high-quality codebase.
 
 - **Languages**: Kotlin (primary), Java (secondary).
 - **Build Tool**: Gradle with Kotlin DSL.
-- **Architecture**: Event-driven Domain-Driven Design (DDD).
+- **Architecture**: Event-driven Command Query Responsibility Segregation (CQRS).
 - **Testing**: JUnit 5
 - **Style**: Kotlin idiomatic code preferred over Java-style code
 - **Tools Used**: Gradle plugins, IntelliJ IDEA Platform, KSP, KotlinPoet 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,7 @@
-# `AGENTS.md`
+This project follows best practices recommended by leading LLM vendors such as OpenAI, Anthropic, and Google.
 
-> Guidance for Large Language Model (LLM) Agents (ChatGPT & Codex) collaborating on this project.
-
----
+- Adhere to the [Spine Event Engine documentation wiki](https://github.com/SpineEventEngine/documentation/wiki) for coding style and contribution procedures.
+- When modifying code, run `./gradlew build` before committing. Changes limited to documentation or comments do not require running tests.
 ## Table of Contents
 1. [The purpose of this document](#the-purpose-of-this-document)
 2. [Project overview](#project-overview)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,183 @@
-# Guidance for Contributors and Agents
+# `AGENTS.md`
 
-This project follows best practices recommended by leading LLM vendors (OpenAI, Anthropic, Google, etc.). Key points include:
+> Guidance for Large Language Model (LLM) Agents (ChatGPT & Codex) collaborating on this project.
+
+---
+
+## 🧠 The purpose of this document
+
+This file defines how LLM agents (e.g. **ChatGPT** and **Codex**) should **interact with the codebase**, **generate content**, and **assist in development workflows** for this project, which is based on **Kotlin** and **Java**. It outlines conventions, expectations, and usage goals to ensure **productive, safe, and consistent collaboration**.
+
+---
+
+## 🛠️ Project overview
+
+- **Languages**: Kotlin (primary), Java (secondary).
+- **Build Tool**: Gradle with Kotlin DSL.
+- **Architecture**: Event-driven Domain-Driven Design (DDD).
+- **Testing**: JUnit 5
+- **Style**: Kotlin idiomatic code preferred over Java-style code
+- **Tools Used**: KotlinPoet, KSP, Gradle plugins, IntelliJ IDEA
+
+---
+
+## 🤖 Agent roles
+
+### 🗨️ ChatGPT
+
+- Explain code, APIs, and architecture
+- Refactor or simplify logic
+- Help with design decisions and trade-offs
+- Generate documentation (KDoc, Markdown)
+- Suggest tests and edge cases
+- Summarize diffs or changes
+- Generate Gradle configurations
+- Assist with naming and conceptual clarity
+
+### 🔧 Codex (code completion/generation)
+
+- Complete functions, classes, and tests
+- Generate Kotlin idioms (e.g., extension functions, DSLs)
+- Follow patterns from nearby code
+- Generate test scaffolds and fixtures
+- Fill in `when` branches, sealed class hierarchies, etc
+
+---
+
+## 🧾 Coding guidelines for Agents
+
+### ✅ Preferred
+
+- Use **idiomatic Kotlin**, including:
+    - Extension functions
+    - `when` expressions
+    - Smart casts
+    - Data classes
+    - Sealed classes
+- Apply **Java interop** only when needed (e.g., using annotations or legacy libraries)
+- Use **Kotlin DSL** when modifying or generating Gradle files
+- Generate code that **compiles cleanly** and **passes static analysis**
+- Respect **existing architecture**, naming conventions, and project structure
+- Use `@file:JvmName`, `@JvmStatic`, etc., where appropriate.
+
+### ❌ Avoid
+
+- Java-style verbosity (e.g., builders with setters)
+- Redundant null checks (`?.let` misuse)
+- Using `!!` unless clearly justified
+- Mixing Groovy and Kotlin DSLs in build logic
+- Overuse of reflection unless requested
+
+### General guidance
 
 - Write clear, incremental commits with descriptive messages.
 - Include automated tests for any code change that alters functionality.
 - Keep pull requests focused and small.
-- Adhere to the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki) for coding style and contribution procedures.
-- When modifying code, run `./gradlew build` before committing. Documentation-only changes do not require running tests.
+- Adhere to the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki) for coding style and
+  contribution procedures.
 
+### Naming convention for variables
+- Prefer simple nouns over composite nouns. E.g., `user` is better than `userAccount`.
+
+---
+
+## Running builds
+
+- When modifying code, run `./gradlew build` before committing.
+- If Protobuf (`.proto`) files are modified **always** run `./gradlew clean build`.
+- Documentation-only changes do not require running tests.
+
+---
+
+## Incrementing a patch version for each pull request
+
+When creating a pull request, update the `version.gradle.kts` file in the root of a project
+by incrementing the last component of the version number by 1.
+
+If the last component has leading zeroes, keep the padding of zeroes so that the width of
+the last component stays the same. For example, the version `"2.0.0-SNAPSHOT.009"` should become
+`"2.0.0-SNAPSHOT.010"`.
+
+---
+
+## 📁 Project structure expectations
+
+```yaml
+<module1>
+  src/
+  ├── main/
+  │ ├── kotlin/ # Kotlin source files
+  │ └── java/ # Legacy Java code
+  ├── test/
+  │ └── kotlin/ # Unit and integration tests
+  build.gradle.kts # Kotlin-based build configuration
+<module2>
+<module3>
+build.gradle.kts # Kotlin-based build configuration
+settings.gradle.kts # Project structure and settings
+README.md # Project overview
+AGENTS.md # LLM agent instructions (this file)
+
+```
+---
+
+## 📄 Documentation Tasks for ChatGPT
+
+- Generate and update **KDoc** for public APIs
+- Draft/update **README.md**, **CONTRIBUTING.md**
+- Suggest better **names** and **abstractions**
+- Help format inline comments and design rationale
+- Generate changelogs based on Git commit summaries
+
+---
+
+## 🧪 Testing Responsibilities
+
+- **Codex** should generate tests for:
+    - Public functions
+    - Edge cases
+    - Custom serializers / deserializers
+    - Extension functions and DSLs
+
+- **ChatGPT** may suggest:
+    - Test coverage improvements
+    - Property-based testing
+    - Mocking and test lifecycle setups
+
+---
+
+## 🚨 Safety Rules for Agents
+
+- Do **not** auto-update external dependencies without explicit request
+- Do **not** inject analytics or telemetry code
+- Flag any usage of unsafe constructs (e.g., reflection, I/O on main thread)
+- Avoid generating blocking calls inside coroutines
+
+---
+
+## 💬 Interaction tips
+
+- Use comments like `// ChatGPT: explain this logic` or `// Codex: complete this function`
+- Use Git commit messages like:
+
+  ```text
+  feat(chatgpt): suggested DSL refactoring for query handlers  
+  fix(codex): completed missing case in sealed class hierarchy  
+
+  ```
+- Encourage `// TODO:` or `// FIXME:` comments to be clarified by ChatGPT
+
+---
+
+## 🧭 LLM Goals
+ - Help developers move faster without sacrificing code quality
+ - Provide language-aware guidance on Kotlin/Java idioms
+ - Lower the barrier to onboarding new contributors
+ - Enable collaborative, explainable, and auditable development with AI
+
+--- 
+
+## 👋 Welcome, Agents!
+ - You are here to help.
+ - Stay consistent, stay clear, and help this Kotlin/Java codebase become more robust,
+   elegant, and maintainable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,11 @@ with AI to maintain a high-quality codebase.
 ## 🛠️ Project overview
 
 - **Languages**: Kotlin (primary), Java (secondary).
-- **Build Tool**: Gradle with Kotlin DSL.
+- **Build tool**: Gradle with Kotlin DSL.
 - **Architecture**: Event-driven Command Query Responsibility Segregation (CQRS).
 - **Testing**: JUnit 5
 - **Style**: Kotlin idiomatic code preferred over Java-style code
-- **Tools Used**: Gradle plugins, IntelliJ IDEA Platform, KSP, KotlinPoet 
+- **Tools used**: Gradle plugins, IntelliJ IDEA Platform, KSP, KotlinPoet 
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Guidance for Contributors and Agents
+
+This project follows best practices recommended by leading LLM vendors (OpenAI, Anthropic, Google, etc.). Key points include:
+
+- Write clear, incremental commits with descriptive messages.
+- Include automated tests for any code change that alters functionality.
+- Keep pull requests focused and small.
+- Adhere to the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki) for coding style and contribution procedures.
+- When modifying code, run `./gradlew build` before committing. Documentation-only changes do not require running tests.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,17 @@
-This project follows best practices recommended by leading LLM vendors such as OpenAI, Anthropic, and Google.
-
-- Keep communication respectful and avoid sharing sensitive data.
-- Follow the [Spine Event Engine documentation wiki](https://github.com/SpineEventEngine/documentation/wiki) for code style and contribution procedures. Referencing the guidelines is sufficient—do not copy code from the wiki.
-- Run `./gradlew build` before committing when modifying code. Changes limited to documentation or comments do not require running tests.
 ## Table of Contents
-1. [The purpose of this document](#the-purpose-of-this-document)
-2. [Project overview](#project-overview)
-3. [Agent roles](#agent-roles)
-4. [Coding guidelines](#coding-guidelines)
+1. [Purpose](#-purpose)
+2. [Project overview](#️-project-overview)
+3. [Agent responsibilities](#-agent-responsibilities)
+4. [Coding guidelines for Agents](#-coding-guidelines-for-agents)
 5. [Running builds](#running-builds)
-6. [Incrementing a version](#incrementing-a-patch-version)
-7. [Documentation tasks](#documentation-tasks)
-8. [Testing responsibilities](#testing-responsibilities)
-9. [Safety rules for Agents](#-safety-rules-for-agents)
-10. [Interaction Tips](#interaction-tips)
+6. [Version policy](#version-policy)
+7. [Project structure expectations](#-project-structure-expectations)
+8. [Documentation tasks](#-documentation-tasks)
+9. [Testing](#-testing)
+10. [Safety rules for Agents](#-safety-rules-for-agents)
+11. [Interaction tips – key to effective collaboration!](#-interaction-tips--key-to-effective-collaboration)
+12. [LLM Goals](#-llm-goals)
+13. [Welcome, Agents!](#-welcome-agents)
 
 ## 🧠 Purpose
 
@@ -112,7 +110,7 @@ Tagging PRs helps the team:
 - The conventions on the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki)
   page and other pages in this Wiki area **take precedence over** standard Kotlin or
   Java conventions.
- 
+
 - Write clear, incremental commits with descriptive messages.
 - Include automated tests for any code change that alters functionality.
 - Keep pull requests focused and small.
@@ -177,7 +175,7 @@ A branch conflict over the version number should be resolved as described below.
    ```bash
    ./gradlew build
    ```
-   
+
 2. If Protobuf (`.proto`) files are modified run:
    ```bash
    ./gradlew clean build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ with AI to maintain a high-quality codebase.
 - **Languages**: Kotlin (primary), Java (secondary).
 - **Build tool**: Gradle with Kotlin DSL.
 - **Architecture**: Event-driven Command Query Responsibility Segregation (CQRS).
+- **Static analysis**: detekt, ErrorProne, Checkstyle, PMD. 
 - **Testing**: JUnit 5, Kotest Assertions, Codecov.
 - **Tools used**: Gradle plugins, IntelliJ IDEA Platform, KSP, KotlinPoet, Dokka. 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@
 4. [Coding guidelines](#coding-guidelines)
 5. [Running builds](#running-builds)
 6. [Incrementing a version](#incrementing-a-patch-version)
-7. [Documentation Tasks](#documentation-tasks)
-8. [Testing Responsibilities](#testing-responsibilities)
-9. [Safety Rules](#safety-rules)
+7. [Documentation tasks](#documentation-tasks)
+8. [Testing responsibilities](#testing-responsibilities)
+9. [Safety rules for Agents](#-safety-rules-for-agents)
 10. [Interaction Tips](#interaction-tips)
 
 ## 🧠 Purpose
@@ -51,12 +51,12 @@ with AI to maintain a high-quality codebase.
 
 | Task/Feature                      | Primary Agent | Supporting Agent | Notes                                      |
 |-----------------------------------|---------------|------------------|--------------------------------------------|
-| Writing Documentation (like KDoc) | ChatGPT       | Codex            | Use for readable, structured docs.         |
-| Explaining APIs/Architecture      | ChatGPT       | -                | Great for clarity in team workflows.       |
-| Code Generation (e.g., tests)     | Codex         | ChatGPT          | Codex produces quick scaffolding.          |
-| Code Refactoring Suggestions      | ChatGPT       | Codex            | Use ChatGPT for design-level improvements. |
-| Completing Functions/Classes      | Codex         | -                | Codex is better for direct completions.    |
-| Debugging/Test Suggestions        | ChatGPT       | Codex            | ChatGPT suggests missing scenarios.        |
+| Writing documentation (like KDoc) | ChatGPT       | Codex            | Use for readable, structured docs.         |
+| Explaining APIs and architecture  | ChatGPT       | -                | Great for clarity in team workflows.       |
+| Code generation (e.g., tests)     | Codex         | ChatGPT          | Codex produces quick scaffolding.          |
+| Code refactoring suggestions      | ChatGPT       | Codex            | Use ChatGPT for design-level improvements. |
+| Completing functions or classes   | Codex         | -                | Codex is better for direct completions.    |
+| Debugging and test suggestions    | ChatGPT       | Codex            | ChatGPT suggests missing scenarios.        |
 
 
 ### Tagging pull request messages
@@ -66,7 +66,7 @@ While crafting GitHub PR messages, tag agent roles as needed:
 feat(chatgpt): Updated README with clearer KDoc examples
 fix(codex): Completed missing `when` branches in tests
 ```
-##### Why tag pull requests?
+#### Why tag pull requests?
 Tagging PRs helps the team:
   - Track which agent contributed to specific changes.
   - Understand whether a PR needs extra human review based on the agent’s role.
@@ -215,10 +215,12 @@ version.gradle.kts # Declares the project version.
 
 ## 📄 Documentation tasks
 
-- Generate and update **KDoc** for `public` and `internal` APIs
-- Suggest better **names** and **abstractions**
-- Help format inline comments and design rationale
-- Generate changelogs based on Git commit summaries
+- Generate and update **KDoc** for `public` and `internal` APIs.
+  Remember to focus on structure for readability.
+
+- Suggest better **names** and **abstractions**.
+
+- Help format inline comments and design rationale.
 
 ---
 
@@ -242,8 +244,6 @@ version.gradle.kts # Declares the project version.
 ---
 
 ## 🚨 Safety rules for Agents
-
-Safety rules ensure that LLM-generated code maintains project scalability and reliability:
 
 - Do **not** auto-update external dependencies without explicit request.
 - Do **not** inject analytics or telemetry code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## Table of Contents
 1. [Purpose](#-purpose)
-2. [Project overview](#️-project-overview)
+2. [Project overview](#-project-overview)
 3. [Agent responsibilities](#-agent-responsibilities)
 4. [Coding guidelines for Agents](#-coding-guidelines-for-agents)
 5. [Running builds](#running-builds)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,10 +164,9 @@ AGENTS.md # LLM agent instructions (this file)
 ```
 ---
 
-## 📄 Documentation tasks for ChatGPT
+## 📄 Documentation tasks
 
-- Generate and update **KDoc** for public APIs
-- Draft/update **README.md**, **CONTRIBUTING.md**
+- Generate and update **KDoc** for `public` and `internal` APIs
 - Suggest better **names** and **abstractions**
 - Help format inline comments and design rationale
 - Generate changelogs based on Git commit summaries
@@ -176,17 +175,20 @@ AGENTS.md # LLM agent instructions (this file)
 
 ## 🧪 Testing responsibilities
 
-- **Codex** should generate tests for:
+- Generate tests for:
     - Public functions
     - Edge cases
-    - Custom serializers / deserializers
     - Extension functions and DSLs
 
-- **ChatGPT** may suggest:
+- Suggest:
     - Test coverage improvements
+    - Performance testing
     - Property-based testing
-    - Mocking and test lifecycle setups
 
+### Testing guidelines
+ - Do not use mocks, use stubs.
+ - Prefer [Kotest assertions](https://kotest.io/docs/assertions/assertions.html) over
+   assertions from JUnit or Google Truth.
 ---
 
 ## 🚨 Safety rules for Agents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ It outlines conventions, expectations, and usage goals to ensure
 
 ## 🤖 Agent roles
 
-### 🗨️ ChatGPT
+### 🗨️ Helping with understanding and improvements
 
 - Explain code, APIs, and architecture
 - Refactor or simplify logic
@@ -55,7 +55,7 @@ It outlines conventions, expectations, and usage goals to ensure
 - Generate Gradle configurations
 - Assist with naming and conceptual clarity
 
-### 🔧 Codex — code completion and code generation
+### 🔧 Code completion and code generation
 
 - Complete functions, classes, and tests
 - Generate Kotlin idioms (e.g., extension functions, DSLs)
@@ -75,19 +75,21 @@ It outlines conventions, expectations, and usage goals to ensure
     - Smart casts
     - Data classes
     - Sealed classes
-2. Apply **Java interop** only when needed (e.g., using annotations or legacy libraries)
-3. Use **Kotlin DSL** when modifying or generating Gradle files
-4. Generate code that **compiles cleanly** and **passes static analysis**
-5. Respect **existing architecture**, naming conventions, and project structure
-6. Use `@file:JvmName`, `@JvmStatic`, etc., where appropriate.
+2. Immutable data structures. 
+3. Apply **Java interop** only when needed (e.g., using annotations or legacy libraries).
+4. Use **Kotlin DSL** when modifying or generating Gradle files.
+5. Generate code that **compiles cleanly** and **passes static analysis**.
+6. Respect **existing architecture**, naming conventions, and project structure.
+7. Use `@file:JvmName`, `@JvmStatic`, etc., where appropriate.
 
 ### ❌ Avoid
 
+- Mutable data structures
 - Java-style verbosity (e.g., builders with setters)
 - Redundant null checks (`?.let` misuse)
 - Using `!!` unless clearly justified
 - Mixing Groovy and Kotlin DSLs in build logic
-- Overuse of reflection unless requested
+- Using reflection unless requested
 
 ### General guidance
 - Adhere to the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 This project follows best practices recommended by leading LLM vendors such as OpenAI, Anthropic, and Google.
 
-- Adhere to the [Spine Event Engine documentation wiki](https://github.com/SpineEventEngine/documentation/wiki) for coding style and contribution procedures.
-- When modifying code, run `./gradlew build` before committing. Changes limited to documentation or comments do not require running tests.
+- Keep communication respectful and avoid sharing sensitive data.
+- Follow the [Spine Event Engine documentation wiki](https://github.com/SpineEventEngine/documentation/wiki) for code style and contribution procedures. Referencing the guidelines is sufficient—do not copy code from the wiki.
+- Run `./gradlew build` before committing when modifying code. Changes limited to documentation or comments do not require running tests.
 ## Table of Contents
 1. [The purpose of this document](#the-purpose-of-this-document)
 2. [Project overview](#project-overview)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,7 @@ Safety rules ensure that LLM-generated code maintains project scalability and re
     // ChatGPT: explain this logic.
     // Codex: complete this function.
    ```
-- Agents, should ensure pull request messages are concise and descriptive:
+- Agents should ensure pull request messages are concise and descriptive:
   ```text
   feat(chatgpt): suggested DSL refactoring for query handlers  
   fix(codex): completed missing case in sealed class hierarchy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,8 @@ version.gradle.kts # Declares the project version.
 
 ## 🚨 Safety rules for Agents
 
+Safety rules ensure that LLM-generated code maintains project scalability and reliability:
+
 - Do **not** auto-update external dependencies without explicit request.
 - Do **not** inject analytics or telemetry code.
 - Flag any usage of unsafe constructs (e.g., reflection, I/O on the main thread).
@@ -268,14 +270,16 @@ version.gradle.kts # Declares the project version.
 
 - When agents or humans add TODO comments, they **must** follow the format described on
   the [dedicated page](https://github.com/SpineEventEngine/documentation/wiki/TODO-comments).
+
 ---
 
 ## 🧭 LLM Goals
- - Help developers move faster without sacrificing code quality
- - Provide language-aware guidance on Kotlin/Java idioms
- - Lower the barrier to onboarding new contributors
- - Enable collaborative, explainable, and auditable development with AI
 
+These goals guide how agents (ChatGPT, Codex) are used in this project to:
+- Help developers move faster without sacrificing code quality
+- Provide language-aware guidance on Kotlin/Java idioms
+- Lower the barrier to onboarding new contributors
+- Enable collaborative, explainable, and auditable development with AI
 --- 
 
 ## 👋 Welcome, Agents!

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,8 @@ with AI to maintain a high-quality codebase.
 - **Languages**: Kotlin (primary), Java (secondary).
 - **Build tool**: Gradle with Kotlin DSL.
 - **Architecture**: Event-driven Command Query Responsibility Segregation (CQRS).
-- **Testing**: JUnit 5
-- **Style**: Kotlin idiomatic code preferred over Java-style code
-- **Tools used**: Gradle plugins, IntelliJ IDEA Platform, KSP, KotlinPoet 
+- **Testing**: JUnit 5, Kotest Assertions, Codecov.
+- **Tools used**: Gradle plugins, IntelliJ IDEA Platform, KSP, KotlinPoet, Dokka. 
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,10 +104,10 @@ Tagging PRs helps the team:
 - Using reflection unless requested
 
 ### General guidance
-- Adhere to the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki)
+- Adhere to the [Spine Event Engine Documentation][spine-docs]
   for coding style and contribution procedures. 
 
-- The conventions on the [Spine Event Engine Documentation](https://github.com/SpineEventEngine/documentation/wiki)
+- The conventions on the [Spine Event Engine Documentation][spine-docs]
   page and other pages in this Wiki area **take precedence over** standard Kotlin or
   Java conventions.
 
@@ -131,7 +131,7 @@ The version number of the project is kept in the file named `version.gradle.kts`
 in the root of the project.
 
 The version numbers in these files follow the conventions of
-[Semantic Versioning 2.0.0](https://semver.org/).
+[Semantic Versioning 2.0.0][semver].
 
 ### Increment a patch version for each pull request
 
@@ -226,7 +226,7 @@ version.gradle.kts # Declares the project version.
 
 ### Guidelines
 - Do not use mocks, use stubs.
-- Prefer [Kotest assertions](https://kotest.io/docs/assertions/assertions.html) over
+- Prefer [Kotest assertions][kotest-assertions] over
   assertions from JUnit or Google Truth.
 
 ### Responsibilities
@@ -267,7 +267,7 @@ version.gradle.kts # Declares the project version.
 - Encourage `// TODO:` or `// FIXME:` comments to be clarified by ChatGPT.
 
 - When agents or humans add TODO comments, they **must** follow the format described on
-  the [dedicated page](https://github.com/SpineEventEngine/documentation/wiki/TODO-comments).
+  the [dedicated page][todo-comments].
 
 ---
 
@@ -284,3 +284,9 @@ These goals guide how agents (ChatGPT, Codex) are used in this project to:
  - You are here to help.
  - Stay consistent, stay clear, and help this Kotlin/Java codebase become more robust,
    elegant, and maintainable.
+
+<!-- External links -->
+[spine-docs]: https://github.com/SpineEventEngine/documentation/wiki
+[semver]: https://semver.org/
+[kotest-assertions]: https://kotest.io/docs/assertions/assertions.html
+[todo-comments]: https://github.com/SpineEventEngine/documentation/wiki/TODO-comments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,28 @@
-How to contribute
-==================
-Thank you for wanting to contribute to Spine. The following links will help you get started:
+# How to contribute
+
+Thank you for wanting to contribute to Spine Event Engine.
+The following links will help you get started:
+
  * [Wiki home][wiki-home] — the home of the framework developer's documentation.
  * [Getting started with Spine in Java][quick-start] — this guide will walk you through
    a minimal client-server “Hello World!” application in Java. 
  * [Introduction][docs-intro] — this section of the Spine Documentation will help you understand
    the foundation of the framework.
-   
-Pull requests
--------------
+
+## Quickstart for Contributors
+
+- Need **help with workflows or explaining code?** Use **ChatGPT**.
+
+- Need **code completions, scaffolds, or idiomatic patterns?** Use **Codex**.
+
+- Add comments in your code to clarify context for agents:
+   ```kotlin
+   // ChatGPT: Explain this API design and suggest improvements. 
+   // Codex: Complete this test function for edge cases.
+   ```
+
+## Pull requests
+
 The work on an improvement starts with creating an issue that describes a bug or a feature. The issue will be used for communications on the proposed improvements. 
 If code changes are going to be introduced, the issue should also have a link to the corresponding Pull Request.
 
@@ -18,8 +32,8 @@ Code contributions should:
   * Formatted according to the code style. See [Wiki home][wiki-home] for the links to
     style guides of the programming languages used in the framework.  
 
-Contributor License Agreement
------------------------------
+## Contributor License Agreement
+
 Contributions to the code of Spine Event Engine framework and its libraries must be accompanied by
 Contributor License Agreement (CLA).
 

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+}

--- a/dependencies.md
+++ b/dependencies.md
@@ -928,7 +928,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1424,7 +1424,7 @@ This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2309,7 +2309,7 @@ This report was generated on **Tue Jun 03 18:00:49 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:49 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4109,7 +4109,7 @@ This report was generated on **Tue Jun 03 18:00:49 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:22 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4994,7 +4994,7 @@ This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5978,7 +5978,7 @@ This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7089,7 +7089,7 @@ This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8930,7 +8930,7 @@ This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:22 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9836,4 +9836,4 @@ This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 18:00:50 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:20:22 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -928,7 +928,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1424,7 +1424,7 @@ This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2309,7 +2309,7 @@ This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4109,7 +4109,7 @@ This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4994,7 +4994,7 @@ This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5978,7 +5978,7 @@ This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7089,7 +7089,7 @@ This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8930,7 +8930,7 @@ This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9836,4 +9836,4 @@ This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:57:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -928,7 +928,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1424,7 +1424,7 @@ This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2309,7 +2309,7 @@ This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2823,7 +2823,7 @@ This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4109,7 +4109,7 @@ This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4994,7 +4994,7 @@ This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5978,7 +5978,7 @@ This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7089,7 +7089,7 @@ This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8930,7 +8930,7 @@ This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9836,4 +9836,4 @@ This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 21:45:52 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-gradle-plugin-api:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:spine-gradle-plugin-api:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -928,12 +928,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:spine-gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1424,12 +1424,12 @@ This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-gradle-root-plugin:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:spine-gradle-root-plugin:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2309,12 +2309,12 @@ This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2823,12 +2823,12 @@ This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4109,12 +4109,12 @@ This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:22 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4994,12 +4994,12 @@ This report was generated on **Fri Jun 20 20:20:22 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -5978,12 +5978,12 @@ This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:spine-psi:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -7089,12 +7089,12 @@ This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:spine-psi-java:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -8930,12 +8930,12 @@ This report was generated on **Fri Jun 20 20:20:21 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:22 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.335`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.336`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9836,4 +9836,4 @@ This report was generated on **Fri Jun 20 20:20:22 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 20 20:20:22 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 20 20:22:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,12 @@
+# Allow Gradle to auto-detect installed JDKs.
+org.gradle.java.installations.auto-detect=true
+
+# Optional: Allow Gradle to download JDKs if needed.
+org.gradle.java.installations.auto-download=true
+
+# Use parallel builds for better performance.
 org.gradle.parallel=true
+#org.gradle.caching=true
 
 # Dokka plugin eats more memory than usual. Therefore, all builds should have enough.
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+UseParallelGC

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.335</version>
+<version>2.0.0-SNAPSHOT.336</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.335")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.336")


### PR DESCRIPTION
This PR adds `AGENTS.md` plugin for guiding ChatGPT and Codex agents.

### Other notable changes
 * Added `org.gradle.toolchains.foojay-resolver-convention` settings plugin under `buildSrc`.
 * Added "Quickstart" secion in `CONTRIBUTERS.md`.

------
https://chatgpt.com/codex/tasks/task_e_6855960aff248333bf2df3420d47687c