### PR TITLE
Allow adding explicit dependencies in `artifactMeta`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -931,14 +931,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1427,14 +1427,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2317,14 +2317,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2833,14 +2833,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4121,14 +4121,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -4629,14 +4629,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -5257,14 +5257,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6147,14 +6147,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -7141,14 +7141,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -8281,14 +8281,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -10151,14 +10151,14 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:38 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.353`
+# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.354`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11066,6 +11066,6 @@ This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 20:13:56 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -931,7 +931,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1427,7 +1427,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2317,7 +2317,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2833,7 +2833,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4121,7 +4121,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4629,7 +4629,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5257,7 +5257,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6147,7 +6147,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7141,7 +7141,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8281,7 +8281,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10151,7 +10151,7 @@ This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:38 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11066,6 +11066,6 @@ This report was generated on **Sat Sep 20 00:18:38 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:18:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaExtension.kt
+++ b/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaExtension.kt
@@ -48,7 +48,7 @@ public open class ArtifactMetaExtension(project: Project) {
     /**
      * A set of explicit Maven dependency notations to be added to the metadata.
      *
-     * Each notation must be in the form "group:artifact:version".
+     * Each notation must be in the form "$group:$artifact:$version".
      */
     public val explicitDependencies: SetProperty<String> =
         project.objects.setProperty(String::class)

--- a/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaExtension.kt
+++ b/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaExtension.kt
@@ -46,10 +46,25 @@ public open class ArtifactMetaExtension(project: Project) {
     public val excludeConfigurations: ExcludeConfigurations = ExcludeConfigurations(project)
 
     /**
+     * A set of explicit Maven dependency notations to be added to the metadata.
+     *
+     * Each notation must be in the form "group:artifact:version".
+     */
+    public val explicitDependencies: SetProperty<String> =
+        project.objects.setProperty(String::class)
+
+    /**
      * Configures [excludeConfigurations] via an action/closure.
      */
     public fun excludeConfigurations(action: Action<ExcludeConfigurations>) {
         action.execute(excludeConfigurations)
+    }
+
+    /**
+     * Adds explicit Maven dependencies to be included into the artifact metadata.
+     */
+    public fun addDependencies(vararg notations: String) {
+        explicitDependencies.addAll(*notations)
     }
 
     internal companion object {

--- a/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPlugin.kt
+++ b/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPlugin.kt
@@ -70,7 +70,7 @@ import org.gradle.kotlin.dsl.register
  *   }
  * ```
  * 
- * ### Defaults
+ * ### Configurations excluded by default
  * 
  * The plugin automatically excludes all configurations having `"test"` in their names.
  * 
@@ -86,6 +86,37 @@ import org.gradle.kotlin.dsl.register
  *    }
  * }
  * ```
+ *
+ * ### Adding dependencies explicitly
+ *
+ * You can explicitly add Maven dependencies to be included into the artifact metadata
+ * regardless of configurations on which the project depends.
+ * One of the use cases would be to add a transitive dependency, that is, a dependency of
+ * an artifact on which a module depends directly.
+ *
+ * Each dependency must be specified in the form `"$group:$artifact:$version"`.
+ *
+ * Kotlin DSL example (`build.gradle.kts`):
+ *
+ * ```kotlin
+ * artifactMeta {
+ *     addDependencies(
+ *         "com.google.protobuf:protobuf-java:4.13.1",
+ *         "org.junit:junit:4.13.2"
+ *     )
+ *
+ *     // OR
+ *
+ *     explicitDependencies.set(setOf(
+ *        "com.google.protobuf:protobuf-java:4.13.1",
+ *        "org.junit:junit:4.13.2"
+ *     ))
+ * }
+ * ```
+ *
+ * Notes:
+ * - Explicitly declared dependencies are merged with those discovered from configurations.
+ * - Duplicates are de-duplicated, and the list is sorted by the group and artifact ID.
  */
 public class ArtifactMetaPlugin : Plugin<Project> {
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.353</version>
+<version>2.0.0-SNAPSHOT.354</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.353")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.354")


### PR DESCRIPTION
This PR extends `artifactMeta` DSL with an ability to add dependencies explicitly. Since only immediate dependencies are added, this DSL is needed for adding transitive dependencies such as Google Protobuf `protoc` artifact.
