### PR TITLE
Allow custom artifact ID in `artifactMeta`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -931,14 +931,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1427,14 +1427,14 @@ This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2317,14 +2317,14 @@ This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2833,14 +2833,14 @@ This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4121,14 +4121,14 @@ This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -4629,14 +4629,14 @@ This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:15 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -5257,14 +5257,14 @@ This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6147,14 +6147,14 @@ This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -7141,14 +7141,14 @@ This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -8281,14 +8281,14 @@ This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -10151,14 +10151,14 @@ This report was generated on **Sat Sep 20 00:41:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.354`
+# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.355`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11066,6 +11066,6 @@ This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 00:41:15 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -931,7 +931,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:06 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1427,7 +1427,7 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:05 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2317,7 +2317,7 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:06 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2833,7 +2833,7 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:05 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4121,7 +4121,7 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:06 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4629,7 +4629,7 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:15 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:06 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5257,7 +5257,7 @@ This report was generated on **Sat Sep 20 14:26:15 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:06 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6147,7 +6147,7 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:06 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7141,7 +7141,7 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:06 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8281,7 +8281,7 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:06 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10151,7 +10151,7 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:07 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11066,6 +11066,6 @@ This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 14:26:14 WEST 2025** using 
+This report was generated on **Sat Sep 20 14:32:06 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaExtension.kt
+++ b/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaExtension.kt
@@ -56,9 +56,10 @@ public open class ArtifactMetaExtension(project: Project) {
         project.objects.setProperty(String::class)
 
     /**
-     * The artifact ID to use in the name of the written resource file.
+     * The artifact ID to use in the name of the written resource file and
+     * for the coordinates of the module written into the file.
      *
-     * If not specified, defaults to the Gradle `project.name`.
+     * If not specified, defaults to the `project.name`.
      */
     public val artifactId: Property<String> =
         project.objects.property(String::class).convention(project.name)

--- a/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaExtension.kt
+++ b/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaExtension.kt
@@ -28,8 +28,10 @@ package io.spine.tools.gradle.jvm.plugin
 
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Nested
+import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.setProperty
 
 /**
@@ -52,6 +54,14 @@ public open class ArtifactMetaExtension(project: Project) {
      */
     public val explicitDependencies: SetProperty<String> =
         project.objects.setProperty(String::class)
+
+    /**
+     * The artifact ID to use in the name of the written resource file.
+     *
+     * If not specified, defaults to the Gradle `project.name`.
+     */
+    public val artifactId: Property<String> =
+        project.objects.property(String::class).convention(project.name)
 
     /**
      * Configures [excludeConfigurations] via an action/closure.

--- a/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPlugin.kt
+++ b/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPlugin.kt
@@ -49,6 +49,26 @@ import org.gradle.kotlin.dsl.register
  *  Where `<artifact-name>` is obtained as the [fileSafeId][io.spine.tools.meta.Module.fileSafeId]
  *  property of the corresponding [Module][io.spine.tools.meta.Module].
  *
+ * #### Overriding the artifact ID
+ *
+ * By default, the artifact ID is taken from `project.name`.
+ *
+ * You can override it via the [`artifactId`][ArtifactMetaExtension.artifactId] property of the
+ * `artifactMeta` extension. Overriding may be necessary when a module is published with the ID
+ * other than `project.name`.
+ *
+ * Changing `artifactId` affects both:
+ *  - the Maven artifact written into the metadata; and
+ *  - the resource file name (because it is derived from the module built from the
+ *    project `group` and the configured `artifactId`).
+ *
+ * Kotlin DSL (`build.gradle.kts`):
+ * ```kotlin
+ * artifactMeta {
+ *     artifactId.set("custom-artifact-id")
+ * }
+ * ```
+ *
  * ### `excludeConfiguration` DSL
  *
  * Use the `artifactMeta` extension to exclude configurations whose dependencies

--- a/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPlugin.kt
+++ b/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPlugin.kt
@@ -44,17 +44,17 @@ import org.gradle.kotlin.dsl.register
  * ### Artifact metadata file
  *
  * The path of the created file is:
- *  * `${project.buildDir}/resources/main/META-INF/io.spine/<artifact-name>.meta`
+ *  * `${project.buildDir}/resources/main/META-INF/io.spine/<artifact-id>.meta`
  *
- *  Where `<artifact-name>` is obtained as the [fileSafeId][io.spine.tools.meta.Module.fileSafeId]
- *  property of the corresponding [Module][io.spine.tools.meta.Module].
+ *  Where `<artifact-id>` is obtained as the [fileSafeId][io.spine.tools.meta.Module.fileSafeId]
+ *  property of the [Module][io.spine.tools.meta.Module] representing the published project.
  *
  * #### Overriding the artifact ID
  *
  * By default, the artifact ID is taken from `project.name`.
  *
  * You can override it via the [`artifactId`][ArtifactMetaExtension.artifactId] property of the
- * `artifactMeta` extension. Overriding may be necessary when a module is published with the ID
+ * `artifactMeta` extension. Overriding may be necessary when the project is published with the ID
  * other than `project.name`.
  *
  * Changing `artifactId` affects both:

--- a/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/WriteArtifactMeta.kt
+++ b/jvm-tool-plugins/src/main/kotlin/io/spine/tools/gradle/jvm/plugin/WriteArtifactMeta.kt
@@ -68,9 +68,12 @@ public abstract class WriteArtifactMeta : DefaultTask() {
         outputDirectory.finalizeValue()
 
         val group = project.group.toString()
-        val name = project.name
-        val module = Module(group, name)
-        val artifact = MavenArtifact(group, name, project.version.toString())
+        val projectName = project.name
+        val extension = project.extensions.findByType(ArtifactMetaExtension::class.java)
+
+        // If the `artifactId` is not specified explicitly, use the project name.
+        val artifactId = extension?.artifactId?.orNull ?: projectName
+        val artifact = MavenArtifact(group, artifactId, project.version.toString())
 
         val dependencies = collectDependencies()
         val artifactMeta = ArtifactMeta(artifact, dependencies)
@@ -78,6 +81,7 @@ public abstract class WriteArtifactMeta : DefaultTask() {
         val outputDir = outputDirectory.get().asFile
         outputDir.mkdirs()
 
+        val module = Module(group, artifactId)
         val fileName = ArtifactMeta.resourcePath(module)
         val file = outputDir.resolve(fileName)
 

--- a/jvm-tool-plugins/src/test/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPluginSpec.kt
+++ b/jvm-tool-plugins/src/test/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPluginSpec.kt
@@ -448,7 +448,7 @@ class ArtifactMetaPluginSpec {
         val file = File(projectDir, "build/$WORKING_DIR/$resourcePath")
         file.exists() shouldBe true
 
-        // Verify the contents still refer to the actual artifact (project name), not the custom ID.
+        // Verify the contents refer to the custom artifactId, as specified.
         val content = file.readText()
         content shouldContain "maven:$group:$explicitArtifactId:$version"
     }

--- a/jvm-tool-plugins/src/test/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPluginSpec.kt
+++ b/jvm-tool-plugins/src/test/kotlin/io/spine/tools/gradle/jvm/plugin/ArtifactMetaPluginSpec.kt
@@ -352,12 +352,12 @@ class ArtifactMetaPluginSpec {
     `include test configurations when exclusions are cleared` {
 
         @Test
-        fun `via the 'clear' DSL`(@TempDir projectDir: File) {
+        fun `via the 'clear' function`(@TempDir projectDir: File) {
             runBuild(projectDir, clearStatement = "clear()")
         }
 
         @Test
-        fun `via get-clear DSL`(@TempDir projectDir: File) {
+        fun `via setting empty set`(@TempDir projectDir: File) {
             runBuild(projectDir, clearStatement = "containing.set(emptySet())")
         }
 
@@ -414,6 +414,43 @@ class ArtifactMetaPluginSpec {
                 it shouldContain dependencies[2]
             }
         }
+    }
+
+    @Test
+    fun `use explicit artifactId in resource file name`(@TempDir projectDir: File) {
+        val group = "test.group"
+        val version = "1.0.0"
+        val explicitArtifactId = "custom-artifact"
+
+        Gradle.buildFile.under(projectDir).writeText(
+            """
+            plugins {
+                id("java")
+                id("io.spine.artifact-meta")
+            }
+
+            group = "$group"
+            version = "$version"
+
+            artifactMeta {
+                artifactId.set("$explicitArtifactId")
+            }
+            """.trimIndent()
+        )
+
+        val task = TaskName.of(WriteArtifactMeta.TASK_NAME)
+        val result = runGradleBuild(projectDir, task)
+
+        result.task(task.path())?.outcome shouldBe TaskOutcome.SUCCESS
+        result.output shouldContain BUILD_SUCCESSFUL
+
+        val resourcePath = ArtifactMeta.resourcePath(Module(group, explicitArtifactId))
+        val file = File(projectDir, "build/$WORKING_DIR/$resourcePath")
+        file.exists() shouldBe true
+
+        // Verify the contents still refer to the actual artifact (project name), not the custom ID.
+        val content = file.readText()
+        content shouldContain "maven:$group:$explicitArtifactId:$version"
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.354</version>
+<version>2.0.0-SNAPSHOT.355</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.354")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.355")


### PR DESCRIPTION
This PR extends the `artifactMeta` DSL with an ability to set a custom `artifactId`.

The default value for the ID is `project.name`. Overriding the default value is necessary when the project is published with the ID other than its name.
