### PR TITLE
Find root extension by type

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -931,14 +931,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1427,14 +1427,14 @@ This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:05 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2317,14 +2317,14 @@ This report was generated on **Sat Sep 27 19:40:05 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -2833,14 +2833,14 @@ This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:05 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4121,14 +4121,14 @@ This report was generated on **Sat Sep 27 19:40:05 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:30 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -4629,14 +4629,14 @@ This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -5257,14 +5257,14 @@ This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6147,14 +6147,14 @@ This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -7141,14 +7141,14 @@ This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -8281,14 +8281,14 @@ This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -10151,14 +10151,14 @@ This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:30 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.356`
+# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.357`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11066,6 +11066,6 @@ This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 27 19:40:06 WEST 2025** using 
+This report was generated on **Mon Sep 29 17:27:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-root-plugin/src/main/kotlin/io/spine/tools/gradle/root/ProjectExts.kt
+++ b/gradle-root-plugin/src/main/kotlin/io/spine/tools/gradle/root/ProjectExts.kt
@@ -27,8 +27,9 @@
 package io.spine.tools.gradle.root
 
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.api.file.Directory
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.getByType
 
 /**
  * Tells if the project already has the [spine][RootExtension] extension.
@@ -38,7 +39,7 @@ import org.gradle.api.file.Directory
  * @see rootExtension
  */
 public val Project.hasRootExtension: Boolean
-    get() = extensions.findByName(RootExtension.NAME) != null
+    get() = extensions.findByType<RootExtension>() != null
 
 /**
  * Obtains the instance of the [spine][RootExtension] extension of the project.
@@ -50,7 +51,9 @@ public val Project.rootExtension: RootExtension
     get() = extensions.getByType<RootExtension>()
 
 /**
- * Obtains the directory which serves as the root for all the Spine plugins.
+ * Obtains the root working directory which serves all Spine project plugins.
+ *
+ * It is expected that plugins would create subdirectories under the root using their IDs.
  *
  * Conventionally, the path to this directory is `$projectDir/build/spine`.
  */

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.356</version>
+<version>2.0.0-SNAPSHOT.357</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.356")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.357")


### PR DESCRIPTION
This PR makes the `Project.rootExtension` search for an extension by its type (`RootExtension`). Previously, it was searched by its name (`"spine"`) which clashed with custom version catalog created in the previous version of the `BuildSpeed` project. 

Even though Gradle is not likely to allow multiple extension with the same name, the type-safe way for obtaining an extension would save on debugging time when a potential clash occurs next time.
