### PR TITLE
Introduce `LazyMeta` and `LazyDependency` classes

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -852,7 +852,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1766,7 +1766,7 @@ This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2238,7 +2238,7 @@ This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3104,7 +3104,7 @@ This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3620,7 +3620,7 @@ This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4908,7 +4908,7 @@ This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5404,7 +5404,7 @@ This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6048,7 +6048,7 @@ This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6914,7 +6914,7 @@ This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7884,7 +7884,7 @@ This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9024,7 +9024,7 @@ This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10882,7 +10882,7 @@ This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11773,6 +11773,6 @@ This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:45:19 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -852,7 +852,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1766,7 +1766,7 @@ This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2238,7 +2238,7 @@ This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3104,7 +3104,7 @@ This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3620,7 +3620,7 @@ This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4908,7 +4908,7 @@ This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5404,7 +5404,7 @@ This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6048,7 +6048,7 @@ This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6914,7 +6914,7 @@ This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7884,7 +7884,7 @@ This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9024,7 +9024,7 @@ This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:57 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10882,7 +10882,7 @@ This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11773,6 +11773,6 @@ This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:23:58 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -852,14 +852,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -1766,14 +1766,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -2238,14 +2238,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3104,14 +3104,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3620,14 +3620,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4908,14 +4908,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:22 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -5404,14 +5404,14 @@ This report was generated on **Fri Oct 03 17:11:22 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -6048,14 +6048,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:02 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6914,14 +6914,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.2.
@@ -7884,14 +7884,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -9024,14 +9024,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -10882,14 +10882,14 @@ This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:22 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.360`
+# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.361`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11773,6 +11773,6 @@ This report was generated on **Fri Oct 03 17:11:22 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 17:11:21 WEST 2025** using 
+This report was generated on **Sun Oct 05 20:02:03 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/jvm-tools/src/main/kotlin/io/spine/tools/meta/LazyMeta.kt
+++ b/jvm-tools/src/main/kotlin/io/spine/tools/meta/LazyMeta.kt
@@ -57,7 +57,8 @@ public abstract class LazyMeta(
     public fun dependency(module: Module): MavenArtifact {
         val found = meta.dependencies.find(module)
             ?: error("Unable to find the dependency `$module` in `$meta`.")
-        return found as MavenArtifact
+        return (found as? MavenArtifact)
+            ?: error("Dependency `$module` found in `$meta`, but is not a MavenArtifact: $found")
     }
 }
 

--- a/jvm-tools/src/main/kotlin/io/spine/tools/meta/LazyMeta.kt
+++ b/jvm-tools/src/main/kotlin/io/spine/tools/meta/LazyMeta.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.meta
+
+/**
+ * Provides lazy loading of [ArtifactMeta] for a [Module].
+ *
+ * The metadata must be written into the resources of the module using
+ * the Artifact Meta Gradle Plugin (ID: `io.spine.artifact-meta`).
+ * Otherwise, accessing the [meta] property would result in an [IllegalStateException].
+ *
+ * @property module The module of the implementing class.
+ * @property meta The lazily loaded metadata of the module to which the implementing class belongs.
+ */
+public abstract class LazyMeta(
+    protected val module: Module,
+) {
+    /**
+     * The meta-data of this artifact.
+     */
+    protected val meta: ArtifactMeta by lazy {
+        ArtifactMeta.loadFromResource(module, this::class.java)
+    }
+
+    /**
+     * Obtains the dependency of this artifact specified by the given [module]
+     * as stored in the module [meta].
+     *
+     * The dependency must be previously written into the module resources using
+     * the Artifact Meta (`io.spine.artifact-meta`) Gradle plugin.
+     * @throws IllegalStateException if no dependency is found.
+     */
+    public fun dependency(module: Module): MavenArtifact {
+        val found = meta.dependencies.find(module)
+            ?: error("Unable to find the dependency `$module` in `$meta`.")
+        return found as MavenArtifact
+    }
+}
+
+/**
+ * A dependency stored in [meta] for the given [module].
+ *
+ * @property meta The metadata of the [module] lazily loaded from resources.
+ * @property module The module of the dependency.
+ * @property artifact The artifact with full coordinates of the dependency.
+ */
+public data class LazyDependency(
+    private val meta: LazyMeta,
+    private val module: Module
+) {
+    public val artifact: MavenArtifact by lazy { meta.dependency(module) }
+}

--- a/jvm-tools/src/main/kotlin/io/spine/tools/meta/LazyMeta.kt
+++ b/jvm-tools/src/main/kotlin/io/spine/tools/meta/LazyMeta.kt
@@ -58,7 +58,9 @@ public abstract class LazyMeta(
         val found = meta.dependencies.find(module)
             ?: error("Unable to find the dependency `$module` in `$meta`.")
         return (found as? MavenArtifact)
-            ?: error("Dependency `$module` found in `$meta`, but is not a MavenArtifact: $found")
+            ?: error(
+                "Dependency `$module` found in `$meta`, but is not a `MavenArtifact`: `$found`."
+            )
     }
 }
 

--- a/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
+++ b/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
@@ -27,6 +27,7 @@
 package io.spine.tools.meta
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
+++ b/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
@@ -63,7 +63,6 @@ internal class LazyMetaSpec {
             // Message contains the missing module and mentions meta.
             ex.message shouldContain missing.toString()
         }
-
     }
 
     @Nested

--- a/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
+++ b/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.meta
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("`LazyMeta` should")
+internal class LazyMetaSpec {
+
+    /**
+     * An implementation that loads meta from test resources at
+     * META-INF/io.spine/test.group_test-artifact.meta
+     */
+    private object TestMeta : LazyMeta(Module("test.group", "test-artifact"))
+
+    @Nested
+    inner class `resolve dependency from meta` {
+        @Test
+        fun `return Maven artifact for a stored dependency`() {
+            val depModule = Module(GRPC_GROUP, "grpc-kotlin-stub")
+
+            val artifact = TestMeta.dependency(depModule)
+
+            artifact shouldBe MavenArtifact(GRPC_GROUP, "grpc-kotlin-stub", "1.2.3")
+        }
+
+        @Test
+        fun `throw if dependency is not found`() {
+            val missing = Module("com.example", "missing-artifact")
+
+            val ex = assertThrows<IllegalStateException> {
+                TestMeta.dependency(missing)
+            }
+            // Message contains the missing module and mentions meta
+            assert(ex.message?.contains("$missing") == true)
+        }
+
+    }
+
+    @Nested
+    inner class `load meta lazily` {
+        @Test
+        fun `throw if meta resource is missing`() {
+            // This module has no corresponding test resource under META-INF/io.spine
+            object : LazyMeta(Module("absent.group", "absent-artifact")) {}.apply {
+                assertThrows<IllegalStateException> {
+                    // Attempting to resolve any dependency should trigger meta loading
+                    dependency(Module(GRPC_GROUP, "grpc-kotlin-stub"))
+                }
+            }
+        }
+
+    }
+
+    @Nested
+    inner class `support 'LazyDependency' wrapper` {
+        @Test
+        fun `resolve artifact via LazyDependency`() {
+            val module = Module(GRPC_GROUP, "protoc-gen-grpc-java")
+            val lazy = LazyDependency(TestMeta, module)
+
+            val artifact = lazy.artifact
+
+            artifact shouldBe MavenArtifact(GRPC_GROUP, "protoc-gen-grpc-java", "1.2.3")
+        }
+
+    }
+
+    companion object {
+        private const val GRPC_GROUP = "io.grpc"
+    }
+}

--- a/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
+++ b/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
@@ -37,7 +37,7 @@ internal class LazyMetaSpec {
 
     /**
      * An implementation that loads meta from test resources at
-     * META-INF/io.spine/test.group_test-artifact.meta
+     * `META-INF/io.spine/test.group_test-artifact.meta`.
      */
     private object TestMeta : LazyMeta(Module("test.group", "test-artifact"))
 
@@ -59,7 +59,7 @@ internal class LazyMetaSpec {
             val ex = assertThrows<IllegalStateException> {
                 TestMeta.dependency(missing)
             }
-            // Message contains the missing module and mentions meta
+            // Message contains the missing module and mentions meta.
             assert(ex.message?.contains("$missing") == true)
         }
 
@@ -69,15 +69,14 @@ internal class LazyMetaSpec {
     inner class `load meta lazily` {
         @Test
         fun `throw if meta resource is missing`() {
-            // This module has no corresponding test resource under META-INF/io.spine
+            // This module has no corresponding test resource under `META-INF/io.spine`.
             object : LazyMeta(Module("absent.group", "absent-artifact")) {}.apply {
                 assertThrows<IllegalStateException> {
-                    // Attempting to resolve any dependency should trigger meta loading
+                    // Attempting to resolve any dependency should trigger meta loading.
                     dependency(Module(GRPC_GROUP, "grpc-kotlin-stub"))
                 }
             }
         }
-
     }
 
     @Nested
@@ -91,7 +90,6 @@ internal class LazyMetaSpec {
 
             artifact shouldBe MavenArtifact(GRPC_GROUP, "protoc-gen-grpc-java", "1.2.3")
         }
-
     }
 
     companion object {

--- a/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
+++ b/jvm-tools/src/test/kotlin/io/spine/tools/meta/LazyMetaSpec.kt
@@ -60,7 +60,7 @@ internal class LazyMetaSpec {
                 TestMeta.dependency(missing)
             }
             // Message contains the missing module and mentions meta.
-            assert(ex.message?.contains("$missing") == true)
+            ex.message shouldContain missing.toString()
         }
 
     }

--- a/jvm-tools/src/test/resources/META-INF/io.spine/test.group_test-artifact.meta
+++ b/jvm-tools/src/test/resources/META-INF/io.spine/test.group_test-artifact.meta
@@ -1,0 +1,3 @@
+maven:test.group:test-artifact:1.0.0
+maven:io.grpc:protoc-gen-grpc-java:1.2.3
+maven:io.grpc:grpc-kotlin-stub:1.2.3

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.360</version>
+<version>2.0.0-SNAPSHOT.361</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.360")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.361")


### PR DESCRIPTION
This PR introduces `LazyMeta` and `LazyDependency` classes that were adopted while working on [this PR in CoreJvm Compiler](https://github.com/SpineEventEngine/core-jvm-compiler/pull/13).

The classes simplify working with the `ArtifactMeta` instances at the usage sites.
