### PR TITLE
Review and strip unused public API

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
@@ -32,7 +32,7 @@ package io.spine.dependency.local
  * See [`SpineEventEngine/ProtoTap`](https://github.com/SpineEventEngine/ProtoTap/).
  */
 @Suppress(
-    "unused" /* Some subprojects do not use ProtoData directly. */,
+    "unused" /* Some subprojects do not use ProtoTap directly. */,
     "ConstPropertyName" /* We use custom convention for artifact properties. */,
     "MemberVisibilityCanBePrivate" /* The properties are used directly by other subprojects. */,
 )

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -38,11 +38,6 @@ object Validation {
      */
     const val version = "2.0.0-SNAPSHOT.446"
 
-    /**
-     * The last version of Validation compatible with ProtoData.
-     */
-    const val pdCompatibleVersion = "2.0.0-SNAPSHOT.342"
-
     const val group = Spine.toolsGroup
     private const val prefix = "validation"
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
@@ -89,7 +89,6 @@ object LicenseReporter {
             excludeGroups = arrayOf(
                 Spine.group,
                 "io.spine.gcloud",
-                "io.spine.protodata",
                 Spine.toolsGroup,
                 "io.spine.validation"
             )

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -828,14 +828,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1734,14 +1734,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -2212,14 +2212,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:09 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:34 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3070,14 +3070,14 @@ This report was generated on **Sat Jun 06 22:43:09 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4151,14 +4151,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5930,14 +5930,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6780,14 +6780,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
@@ -7547,14 +7547,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:36 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8405,14 +8405,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.11.1.
@@ -9367,14 +9367,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10237,14 +10237,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -11345,14 +11345,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -13167,14 +13167,14 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:38 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.395`
+# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.396`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14054,6 +14054,6 @@ This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 06 22:43:10 WEST 2026** using 
+This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.395</version>
+<version>2.0.0-SNAPSHOT.396</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -410,6 +410,11 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>abi-tools</artifactId>
+    <version>2.3.21</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-assignment-compiler-plugin-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
@@ -428,6 +433,11 @@ all modules and does not describe the project structure per-subproject.
     <artifactId>kotlin-gradle-plugin-api</artifactId>
     <version>2.3.21</version>
     <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
+    <version>2.3.21</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>

--- a/jvm-tools/src/test/kotlin/io/spine/tools/jvm/jar/KManifestSpec.kt
+++ b/jvm-tools/src/test/kotlin/io/spine/tools/jvm/jar/KManifestSpec.kt
@@ -27,6 +27,7 @@
 package io.spine.tools.jvm.jar
 
 import com.google.common.truth.Truth.assertWithMessage
+import io.kotest.matchers.Matcher
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.beEmpty
@@ -61,9 +62,9 @@ class KManifestSpec {
 
     @Test
     fun `load from a JAR for a class packaged in it`() {
-        // Guava is a binary dependency on the test classpath, so its classes
+        // Kotest is a binary dependency on the test classpath, so its classes
         // are loaded via a `JarURLConnection`.
-        val cls = com.google.common.base.Preconditions::class.java
+        val cls = Matcher::class.java
 
         val manifest = KManifest.load(cls)
 

--- a/tool-base/src/main/java/io/spine/tools/code/Indent.java
+++ b/tool-base/src/main/java/io/spine/tools/code/Indent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +130,6 @@ public final class Indent implements Element, Serializable {
     /**
      * Obtains an instance shifted to the right by one level.
      */
-    @SuppressWarnings("unused") /* Part of the public API. */
     public Indent shiftedRight() {
         return new Indent(size, level + 1);
     }
@@ -141,7 +140,6 @@ public final class Indent implements Element, Serializable {
      * @throws IllegalStateException
      *          if this indentation is already at the zero column
      */
-    @SuppressWarnings("unused") /* Part of the public API. */
     public Indent shiftedLeft() {
         checkState(level > 0, "Already at zero. Cannot shift to the left more.");
         return new Indent(size, level - 1);

--- a/tool-base/src/main/java/io/spine/tools/dart/fs/DartFile.java
+++ b/tool-base/src/main/java/io/spine/tools/dart/fs/DartFile.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -45,7 +45,6 @@ public final class DartFile extends FileWithImports {
     /**
      * Reads the file from the local file system.
      */
-    @SuppressWarnings("unused") /* Part of the public API. */
     public static DartFile read(Path path) {
         checkNotNull(path);
         var file = new DartFile(path);

--- a/tool-base/src/main/java/io/spine/tools/dart/fs/ProtocPluginPath.java
+++ b/tool-base/src/main/java/io/spine/tools/dart/fs/ProtocPluginPath.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -27,6 +27,7 @@
 package io.spine.tools.dart.fs;
 
 import io.spine.tools.OsFamily;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.nio.file.Path;
 
@@ -39,7 +40,6 @@ import static java.nio.file.Files.exists;
  * <p>See <a href="https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path">
  * Pub documentation</a>.
  */
-@SuppressWarnings("unused") /* Part of the public API. */
 public final class ProtocPluginPath {
 
     private static final boolean WINDOWS = OsFamily.Windows.isCurrent();
@@ -49,7 +49,7 @@ public final class ProtocPluginPath {
     private static final String DOC_LINK =
             "https://github.com/dart-lang/protobuf/tree/master/protoc_plugin";
 
-    private static Path resolved = null;
+    private static @MonotonicNonNull Path resolved = null;
 
     /** Prevents the utility class instantiation. */
     private ProtocPluginPath() {

--- a/tool-base/src/main/java/io/spine/tools/fs/ExternalModule.java
+++ b/tool-base/src/main/java/io/spine/tools/fs/ExternalModule.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -145,7 +145,6 @@ public final class ExternalModule {
     /**
      * All the modules in {@link #spineWeb()} and {@link #spineUsers()}.
      */
-    @SuppressWarnings("unused") /* Part of the public API. */
     public static ImmutableList<ExternalModule> predefinedModules() {
         return ImmutableList.of(spineWeb(), spineUsers());
     }

--- a/tool-base/src/main/java/io/spine/tools/fs/ExternalModules.java
+++ b/tool-base/src/main/java/io/spine/tools/fs/ExternalModules.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -55,7 +55,6 @@ public final class ExternalModules {
     /**
      * Creates a new instance with the passed modules.
      */
-    @SuppressWarnings("unused") /* Part of the public API. */
     public ExternalModules(ExternalModule... modules) {
         this(ImmutableList.copyOf(modules));
     }
@@ -63,7 +62,6 @@ public final class ExternalModules {
     /**
      * Creates an instance from a raw representation from a Gradle extension.
      */
-    @SuppressWarnings("unused") /* Part of the public API. */
     public ExternalModules(Map<String, List<String>> modules) {
         this(convert(checkNotNull(modules)));
     }

--- a/tool-base/src/main/java/io/spine/tools/fs/FileWithImports.java
+++ b/tool-base/src/main/java/io/spine/tools/fs/FileWithImports.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -44,7 +44,6 @@ public abstract class FileWithImports extends AbstractSourceFile {
     /**
      * Resolves the relative imports in the file into absolute ones with the given modules.
      */
-    @SuppressWarnings("unused") /* Part of the public API. */
     public void resolveImports(Path generatedRoot, ExternalModules modules) {
         load();
         ImmutableList.Builder<String> newLines = ImmutableList.builder();

--- a/tool-base/src/main/java/io/spine/tools/java/fs/DefaultJavaPaths.java
+++ b/tool-base/src/main/java/io/spine/tools/java/fs/DefaultJavaPaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,6 @@ public final class DefaultJavaPaths extends DefaultPaths {
         return at(projectDir.toPath());
     }
 
-    @SuppressWarnings("unused") /* Part of the public API. */
     public Src src() {
         return new Src(projectDir());
     }

--- a/tool-base/src/main/java/io/spine/tools/java/fs/FileName.java
+++ b/tool-base/src/main/java/io/spine/tools/java/fs/FileName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,6 @@ public final class FileName extends AbstractFileName<FileName> {
      * @param path  the target file path
      * @return {@code true} in case if the file has the .java extension.
      */
-    @SuppressWarnings("unused") /* Part of the public API. */
     public static boolean isJava(Path path) {
         checkNotNull(path);
         return path.toString()

--- a/tool-base/src/main/java/io/spine/tools/java/javadoc/JavadocText.java
+++ b/tool-base/src/main/java/io/spine/tools/java/javadoc/JavadocText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,6 @@ public class JavadocText extends StringTypeValue {
         return new JavadocText(escapedText);
     }
 
-    @SuppressWarnings("unused") /* Part of the public API. */
     public static JavadocText fromUnescaped(String unescapedText) {
         return new JavadocText(JavadocEscaper.escape(unescapedText));
     }
@@ -64,7 +63,6 @@ public class JavadocText extends StringTypeValue {
      *
      * @return the text wrapped in the tags
      */
-    @SuppressWarnings("unused") /* Part of the public API. */
     public JavadocText inPreTags() {
         var inTags = OPENING_PRE +
                 LINE_SEPARATOR +

--- a/tool-base/src/main/java/io/spine/tools/js/fs/DefaultJsPaths.java
+++ b/tool-base/src/main/java/io/spine/tools/js/fs/DefaultJsPaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 @Internal
 @Immutable
-@SuppressWarnings("unused") /* Part of the public API. */
 public final class DefaultJsPaths extends DefaultPaths {
 
     private static final String ROOT_NAME = "js";

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.395")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.396")


### PR DESCRIPTION
## What

Resolves #11.

Reviewed every `tool-base` element marked
`@SuppressWarnings("unused") /* Part of the public API. */` and traced each
across this repository's tests and downstream `SpineEventEngine` consumers.

**Finding:** all 13 are genuinely live — each has a real downstream consumer
*and* in-repo test coverage. None are dead, so nothing was removed from the
API. Instead, the now-stale suppressions are dropped: recent test additions
mean the in-repo tests already satisfy the unused-declaration inspection, so
the annotations were redundant.

| Element | Downstream consumer |
|---|---|
| `DefaultJsPaths` | mc-js |
| `ProtocPluginPath` | mc-dart |
| `DartFile.read` | mc-dart |
| `JavadocText.fromUnescaped` / `inPreTags` | core-jvm-compiler |
| `DefaultJavaPaths.src` | protobuf-setup-plugins, core-jvm-compiler |
| `Indent.shiftedRight` / `shiftedLeft` | mc-js |
| `FileName.isJava` | doc-tools |
| `ExternalModule.predefinedModules` | mc-js |
| `ExternalModules(ExternalModule...)` / `(Map<...>)` | mc-js, mc-dart |
| `FileWithImports.resolveImports` | mc-dart |

## Verification

- `./gradlew build dokkaGenerate` — **BUILD SUCCESSFUL**
- `:tool-base:test` — 219 passed, 0 failed, 1 skipped
- Reviewers: `spine-code-review` APPROVE, `kotlin-engineer` APPROVE
- Version bumped `2.0.0-SNAPSHOT.395` → `.396`

## Note

This branch also carries two incidental maintenance commits that predate this
work (`Update config`, and a `KManifestSpec` test-matcher cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
