### PR TITLE
Address build deprecation warnings: PMD ruleset and test task creation

### DIFF
--- a/buildSrc/quality/pmd.xml
+++ b/buildSrc/quality/pmd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2025, TeamDev. All rights reserved.
+  ~ Copyright 2026, TeamDev. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -60,10 +60,10 @@
     <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
     <rule ref="category/java/codestyle.xml/ExtendsObject"/>
     <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
-    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
     <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
     <rule ref="category/java/codestyle.xml/NoPackage"/>
     <rule ref="category/java/codestyle.xml/PackageCase"/>
+    <rule ref="category/java/codestyle.xml/TypeParameterNamingConventions"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
 

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/task/GradleTaskTest.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/task/GradleTaskTest.kt
@@ -45,7 +45,7 @@ class GradleTaskTest {
     @Test
     fun `create an instance from an existing Gradle task`() {
         val project = ProjectBuilder.builder().build()
-        val task = project.tasks.create("existingTask")
+        val task = project.tasks.register("existingTask").get()
 
         val gradleTask = GradleTask.from(task)
 
@@ -58,7 +58,7 @@ class GradleTaskTest {
     @Test
     fun `provide a string representation`() {
         val project = ProjectBuilder.builder().build()
-        val task = project.tasks.create("aTask")
+        val task = project.tasks.register("aTask").get()
 
         GradleTask.from(task).toString() shouldContain "GradleTask"
     }
@@ -66,8 +66,8 @@ class GradleTaskTest {
     @Test
     fun `support equality`() {
         val project = ProjectBuilder.builder().build()
-        val taskA = project.tasks.create("taskA")
-        val taskB = project.tasks.create("taskB")
+        val taskA = project.tasks.register("taskA").get()
+        val taskB = project.tasks.register("taskB").get()
 
         EqualsTester()
             .addEqualityGroup(GradleTask.from(taskA), GradleTask.from(taskA))

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/task/TaskDependenciesSpec.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/task/TaskDependenciesSpec.kt
@@ -43,8 +43,8 @@ internal class TaskDependenciesSpec {
     @BeforeEach
     fun setUp() {
         val project = ProjectBuilder.builder().build()
-        ontoTask = project.tasks.create("ontoTask")
-        task = project.tasks.create("dependent")
+        ontoTask = project.tasks.register("ontoTask").get()
+        task = project.tasks.register("dependent").get()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Clears the two classes of deprecation warning surfaced when building `tool-base`.

### PMD settings
`pmdMain` warned that `category/java/codestyle.xml/GenericsNaming` is deprecated (since PMD 7.17.0) and scheduled for removal in PMD 8.0.0:

```
Warning at buildSrc/quality/pmd.xml:63:5
  Discontinue using Rule name category/java/codestyle.xml/GenericsNaming as it is
  scheduled for removal from PMD. PMD 8.0.0 will remove support for this Rule.
```

Replaced it with its official successor `TypeParameterNamingConventions`, which enforces the same single-uppercase-letter convention for type parameters by default. Copyright year bumped to 2026.

> `buildSrc/quality/pmd.xml` is distributed by the **config** repository, so the same change is propagated there (see the companion PR in `SpineEventEngine/config`). The two files are kept byte-identical.

### Test code
`compileTestKotlin` warned on the eager, deprecated `TaskContainer.create(String): Task` in `GradleTaskTest` and `TaskDependenciesSpec`:

```
w: .../task/GradleTaskTest.kt:48:34 'fun create(name: String): Task' is deprecated. Deprecated in Java.
w: .../task/TaskDependenciesSpec.kt:46:34 'fun create(name: String): Task' is deprecated. Deprecated in Java.
```

Switched all six task fixtures to the lazy `project.tasks.register(name).get()`. `.get()` realises the provider to the `Task` the assertions need — no behaviour change.

## Verification

The full Gradle build could not be run in this environment: its network policy blocks the Spine SNAPSHOT plugins the root build resolves (`jvm-tool-plugins-all`, `protobuf-setup-plugins` return 403 from GitHub Packages, Google Artifact Registry, and mycloudrepo). Instead:

- the PMD change was validated against PMD 7.25.0's own ruleset XML — the successor rule exists, is not deprecated, and defaults to the same convention;
- the test change is a type-safe, standard Gradle lazy-API migration.

CI is the final check.

https://claude.ai/code/session_014TVLouXfDWCg1sTQVW3ssM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TVLouXfDWCg1sTQVW3ssM)_