### PR TITLE
Address deprecations

### DIFF
--- a/buildSrc/quality/pmd.xml
+++ b/buildSrc/quality/pmd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2025, TeamDev. All rights reserved.
+  ~ Copyright 2026, TeamDev. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -60,10 +60,10 @@
     <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
     <rule ref="category/java/codestyle.xml/ExtendsObject"/>
     <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
-    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
     <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
     <rule ref="category/java/codestyle.xml/NoPackage"/>
     <rule ref="category/java/codestyle.xml/PackageCase"/>
+    <rule ref="category/java/codestyle.xml/TypeParameterNamingConventions"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object Base {
     const val version = "2.0.0-SNAPSHOT.400"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.400"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.403"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -828,14 +828,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1734,14 +1734,14 @@ This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -2212,14 +2212,14 @@ This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:34 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3070,14 +3070,14 @@ This report was generated on **Sun Jun 07 19:17:34 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4151,14 +4151,14 @@ This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5930,14 +5930,14 @@ This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6780,14 +6780,14 @@ This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
@@ -7547,14 +7547,14 @@ This report was generated on **Sun Jun 07 19:17:35 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:36 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8405,14 +8405,14 @@ This report was generated on **Sun Jun 07 19:17:36 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.11.1.
@@ -9367,14 +9367,14 @@ This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10237,14 +10237,14 @@ This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -11345,14 +11345,14 @@ This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -13167,14 +13167,14 @@ This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:38 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.396`
+# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.397`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14054,6 +14054,6 @@ This report was generated on **Sun Jun 07 19:17:38 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 19:17:37 WEST 2026** using 
+This report was generated on **Mon Jun 08 15:00:17 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.396</version>
+<version>2.0.0-SNAPSHOT.397</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -410,11 +410,6 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
-    <artifactId>abi-tools</artifactId>
-    <version>2.3.21</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-assignment-compiler-plugin-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
@@ -433,11 +428,6 @@ all modules and does not describe the project structure per-subproject.
     <artifactId>kotlin-gradle-plugin-api</artifactId>
     <version>2.3.21</version>
     <scope>provided</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.kotlin</groupId>
-    <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
-    <version>2.3.21</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/task/GradleTaskTest.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/task/GradleTaskTest.kt
@@ -45,7 +45,7 @@ class GradleTaskTest {
     @Test
     fun `create an instance from an existing Gradle task`() {
         val project = ProjectBuilder.builder().build()
-        val task = project.tasks.create("existingTask")
+        val task = project.tasks.register("existingTask").get()
 
         val gradleTask = GradleTask.from(task)
 
@@ -58,7 +58,7 @@ class GradleTaskTest {
     @Test
     fun `provide a string representation`() {
         val project = ProjectBuilder.builder().build()
-        val task = project.tasks.create("aTask")
+        val task = project.tasks.register("aTask").get()
 
         GradleTask.from(task).toString() shouldContain "GradleTask"
     }
@@ -66,8 +66,8 @@ class GradleTaskTest {
     @Test
     fun `support equality`() {
         val project = ProjectBuilder.builder().build()
-        val taskA = project.tasks.create("taskA")
-        val taskB = project.tasks.create("taskB")
+        val taskA = project.tasks.register("taskA").get()
+        val taskB = project.tasks.register("taskB").get()
 
         EqualsTester()
             .addEqualityGroup(GradleTask.from(taskA), GradleTask.from(taskA))

--- a/plugin-base/src/test/kotlin/io/spine/tools/gradle/task/TaskDependenciesSpec.kt
+++ b/plugin-base/src/test/kotlin/io/spine/tools/gradle/task/TaskDependenciesSpec.kt
@@ -43,8 +43,8 @@ internal class TaskDependenciesSpec {
     @BeforeEach
     fun setUp() {
         val project = ProjectBuilder.builder().build()
-        ontoTask = project.tasks.create("ontoTask")
-        task = project.tasks.create("dependent")
+        ontoTask = project.tasks.register("ontoTask").get()
+        task = project.tasks.register("dependent").get()
     }
 
     @Test

--- a/psi-java/src/test/kotlin/io/spine/tools/psi/PsiElementExtsSpec.kt
+++ b/psi-java/src/test/kotlin/io/spine/tools/psi/PsiElementExtsSpec.kt
@@ -49,9 +49,9 @@ internal class PsiElementExtsSpec {
      * to a member of `PsiFile`.
      */
     private fun loadClass(tempDir: Path) =
-        (FileSystem.load(tempDir.resolve("Stub.java").apply {
+        FileSystem.load(tempDir.resolve("Stub.java").apply {
             writeText("class Stub {}")
-        }) as PsiJavaFile).topLevelClass
+        }).topLevelClass
 
     @Test
     fun `obtain the virtual file of an element`(@TempDir tempDir: Path) {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.396")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.397")


### PR DESCRIPTION
## Summary

Clears the two classes of deprecation warning surfaced when building `tool-base`.

### PMD settings
`pmdMain` warned that `category/java/codestyle.xml/GenericsNaming` is deprecated (since PMD 7.17.0) and scheduled for removal in PMD 8.0.0:

```
Warning at buildSrc/quality/pmd.xml:63:5
  Discontinue using Rule name category/java/codestyle.xml/GenericsNaming as it is
  scheduled for removal from PMD. PMD 8.0.0 will remove support for this Rule.
```

Replaced it with its official successor `TypeParameterNamingConventions`, which enforces the same single-uppercase-letter convention for type parameters by default. Copyright year bumped to 2026.

> `buildSrc/quality/pmd.xml` is distributed by the **config** repository, so the same change is propagated there (see the companion PR in `SpineEventEngine/config`). The two files are kept byte-identical.

### Test code
`compileTestKotlin` warned on the eager, deprecated `TaskContainer.create(String): Task` in `GradleTaskTest` and `TaskDependenciesSpec`:

```
w: .../task/GradleTaskTest.kt:48:34 'fun create(name: String): Task' is deprecated. Deprecated in Java.
w: .../task/TaskDependenciesSpec.kt:46:34 'fun create(name: String): Task' is deprecated. Deprecated in Java.
```

Switched all six task fixtures to the lazy `project.tasks.register(name).get()`. `.get()` realises the provider to the `Task` the assertions need — no behaviour change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014TVLouXfDWCg1sTQVW3ssM)_