### PR TITLE
Stop bundling third-party code in the IntelliJ uber JARs

### DIFF
--- a/.agents/tasks/unshade-intellij-platform-third-party.md
+++ b/.agents/tasks/unshade-intellij-platform-third-party.md
@@ -158,11 +158,60 @@ identical treatment:
   artifacts explicitly if ever needed): `org.jetbrains.kotlin(x)` (provided,
   as before), `org.jetbrains.pty4j`, `org.jetbrains.jediterm` (terminal),
   `org.jvnet.winp` (Windows process management; its DLLs were excluded
-  from the old shade anyway).
+  from the old shade anyway), `org.bouncycastle` (cryptography; see below).
+- **Dropped modules** — the same treatment at artifact granularity, for
+  groups whose *other* artifacts are declared:
+  `org.jetbrains:marketplace-zip-signer` (the group also holds `annotations`,
+  which consumers need).
 - **Central audit**: every POM candidate of both modules verified against
   `repo1.maven.org` — 85/86 present; the miss (`org.jetbrains.intellij:blockmap`)
   is shaded instead (self-namespaced package). `marketplace-zip-signer`'s
   Central POM does not reference `blockmap`, so declaring it is safe.
+
+### The BouncyCastle clash (2026-08-12)
+
+Reported downstream from `core-jvm-compiler`'s integration tests, as
+`Cause 19` of a multi-conflict failure:
+
+    Conflict found for module 'org.bouncycastle:bcprov-jdk15on':
+        between versions 1.69 and 1.64
+
+`ide-impl` reaches BouncyCastle twice, at versions that disagree:
+
+| POM entry (as published in `.410`)           | Reached via         | Requires                                      |
+|----------------------------------------------|---------------------|-----------------------------------------------|
+| `org.bouncycastle:bcpg-jdk15on:1.69`         | `remote-dev-util`   | `bcprov-jdk15on:1.69`                         |
+| `org.jetbrains:marketplace-zip-signer:0.1.3` | `ide-impl` directly | `bcpkix-jdk15on:1.64` → `bcprov-jdk15on:1.64` |
+
+Neither `bcprov` nor `bcpkix` appears on *this* repo's runtime classpath —
+only the two entry points above do — so the clash is invisible here and
+surfaces only in consumers, which re-resolve each declared entry's own POM.
+Both entry points are remote-development and plugin-signing machinery, never
+exercised by headless PSI, i.e. the same category as the pty4j/jediterm/winp
+drops. Dropping both removes the whole cryptography surface rather than
+merely aligning it, so no future consumer inherits the clash. POM entries:
+86 → 84; `org.jetbrains:annotations` and `annotations-java5` verified to
+survive the artifact-level drop.
+
+### Open — the same defect class remains for 10 other modules
+
+The flattened POM lists every resolved artifact at *this repo's* version, but
+each listed entry still carries its own transitive graph, which re-requests
+older versions. Resolving the regenerated 84-entry POM in a bare consumer
+with `failOnVersionConflict()` yields 10 conflicting modules:
+`error_prone_annotations`, `commons-{codec,collections,io,logging}`,
+`kotlin-{stdlib,stdlib-common,reflect}`, `org.jetbrains:annotations`,
+`objenesis`. The standard Spine `forceVersions()` already covers the
+ErrorProne and Kotlin ones; the `commons-*`, `annotations` and `objenesis`
+conflicts are new boilerplate for consumers.
+
+The dependency-less POM that preceded this task had none of these, so the
+task introduces them. Measured remedy: declare each entry **non-transitive**
+(`<exclusions>` of `*:*`). The published list is already the complete
+flattened closure, so nothing is lost, and each module is then requested at
+exactly one version — the same 84 artifacts resolve with zero conflicts.
+Consumers can still upgrade any entry by ordinary resolution, so the Jib
+`commons-compress` fix is preserved. Not implemented; needs a decision.
 - **Subtraction vs Shadow transforms**: the `intellij-platform-java`
   subtraction filter sees pre-transform source paths while the sibling JAR
   stores post-transform ones. `IntelliJUberJar.sourceFormOf()` reverse-maps

--- a/.agents/tasks/unshade-intellij-platform-third-party.md
+++ b/.agents/tasks/unshade-intellij-platform-third-party.md
@@ -1,0 +1,220 @@
+---
+slug: unshade-intellij-platform-third-party
+branch: unshade-intellij-platform-third-party
+owner: claude
+status: in-progress
+started: 2026-08-12
+---
+
+## Goal
+
+The `intellij-platform` uber JAR stops bundling unrelocated third-party classes,
+so that it can no longer shadow genuine artifacts on a consumer's build
+classpath. Third-party components that exist on Maven Central become normal
+dependencies of the published artifact; JetBrains forks that cannot be, are
+relocated.
+
+## Context — the incident that surfaced this
+
+In `delivery-server`, `./gradlew :delivery-server-cloud-run:jibDockerBuild`
+failed with:
+
+    NoSuchMethodError:
+        'void org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+             .putArchiveEntry(TarArchiveEntry)'
+
+The Jib Gradle plugin 3.4.4 compiles against `commons-compress:1.26.0`, where
+that overload exists. `io.spine.tools:intellij-platform` — reaching the root
+buildscript classpath transitively via `compiler-gradle-plugin` → `psi-java` →
+`psi` — bundles `org.apache.commons.compress.**` from **1.21**, unrelocated.
+The root buildscript classloader is a parent of every subproject's plugin
+classloader, and parent-first delegation served the 1.21 copy to Jib.
+
+Diagnosis required loading the class from the buildscript classloader and
+printing its code source; `./gradlew buildEnvironment` is *misleading* here —
+it reports a clean, resolvable `commons-compress:1.26.0` because the shaded
+copy is not a dependency at all, it is bytecode inside another artifact.
+For the same reason no version constraint, BOM, or `force(...)` can fix it.
+
+The consumer-side workaround (delivery-server PR #62) declares the genuine
+`commons-compress` **first** on the root buildscript classpath so it wins by
+ordering. It works, but classpath order is load-bearing and every consumer
+repo needs to know the trick. This task removes the cause.
+
+## Analysis
+
+### How the third-party code gets in
+
+`intellij-platform/build.gradle.kts` applies `uber-jar-module`, whose
+`shadowJar` shades the **entire resolved runtime classpath** of the declared
+`com.jetbrains.intellij.platform:{core,util,core-impl,code-style}` (v213.7172.53)
+dependencies. The `exclude(...)` list filters resource *directories* (icons,
+templates, `kotlin/**`, …) but no *artifacts* — and there is no `relocate(...)`.
+The third-party code is not vendored by JetBrains inside their jars; it arrives
+as ordinary Maven dependencies declared in their POMs, and Shadow swallows it
+all. The published `fatJar` publication is `artifact(tasks.shadowJar)` with no
+component, so the POM declares **zero** dependencies: 28 MB, 575 packages,
+opaque to dependency resolution.
+
+### What is bundled (measured from `2.0.0-SNAPSHOT.404`)
+
+Genuine Maven Central artifacts, bundled unrelocated:
+
+| Bundled component                                                                        | Version (per IJ 213 POMs) | Packages                                           |
+|------------------------------------------------------------------------------------------|---------------------------|----------------------------------------------------|
+| `com.google.guava:guava` (+`failureaccess`)                                              | 31.0.1-jre                | `com.google.common.**`, `com.google.thirdparty.**` |
+| `org.apache.commons:commons-compress`                                                    | 1.21                      | `org.apache.commons.compress.**`                   |
+| `com.github.ben-manes.caffeine:caffeine`                                                 | (transitive)              | `com.github.benmanes.caffeine.**`                  |
+| `io.netty` (buffer, util — partial)                                                      | (transitive)              | `io.netty.buffer.**`, `io.netty.util.**`           |
+| `com.fasterxml:aalto-xml`, `org.codehaus:stax2`                                          | 1.3.0                     | `com.fasterxml.aalto.**`, `org.codehaus.stax2.**`  |
+| `oro:oro`                                                                                | 2.0.8                     | `org.apache.oro.**`                                |
+| `org.lz4:lz4-pure-java`                                                                  | 1.8.0                     | `net.jpountz.**`                                   |
+| `dk.brics:automaton`                                                                     | 1.12-1                    | `dk.brics.automaton.**`                            |
+| `org.jspecify`, `net.jcip`, `org.jetbrains:annotations`                                  | —                         | annotations                                        |
+| Batik + xmlgraphics, `org.imgscalr`, `net.n3.nanoxml`, `it.unimi.dsi` (fastutil classes) | —                         | various                                            |
+
+JetBrains **forks** (published only in the JetBrains `intellij-dependencies`
+repository, *not* Central), also unrelocated:
+
+| Fork artifact                                  | Claims package        |
+|------------------------------------------------|-----------------------|
+| `org.jetbrains.intellij.deps:jdom:2.0.6`       | `org.jdom.**`         |
+| `org.jetbrains.intellij.deps:log4j:1.2.17.2`   | `org.apache.log4j.**` |
+| `org.jetbrains.intellij.deps:trove4j`          | `gnu.trove.**`        |
+| `org.jetbrains.intellij.deps.jna:jna-platform` | `com.sun.jna.**`      |
+| `org.jetbrains.intellij.deps.fastutil`         | `it.unimi.dsi.**`     |
+
+### The two IJ fat JARs are a layered pair, not independent bundles
+
+`intellij-platform-java/build.gradle.kts` (`tasks.shadowJar`, `doFirst` block)
+computes its exclusions **from the actual contents of the `intellij-platform`
+JAR**: it visits every path in the sibling archive and excludes exactly those
+paths from its own shade. Consequences for this task:
+
+- Removing an entry from the `intellij-platform` shade silently *adds* it to
+  the `intellij-platform-java` shade on the next build (measured: excluding
+  JNA from the platform JAR resurfaced all 1477 `com/sun/jna` entries in the
+  java JAR). Exclusions of shared transitives must live in the shared
+  `uber-jar-module` list, and the eventual artifact include-filters must be
+  applied to **both** modules consistently.
+- `intellij-platform-java` additionally bundles its own unrelocated
+  third-party code not present in the platform JAR, measured in
+  `2.0.0-SNAPSHOT.410`: `com/pty4j/**` (83 entries,
+  `org.jetbrains.pty4j:pty4j` exists on Central) and `com/jediterm/**`
+  (187 entries, `org.jetbrains.jediterm` exists on Central) — terminal
+  machinery, unused by headless PSI, candidates for the same treatment as
+  the rest of the Central-artifact bucket.
+
+### Measured collision surface in one consumer
+
+Intersecting the bundle with `delivery-server`'s root buildscript classpath
+(96 artifacts): **6 artifacts / 58 packages** overlap — `commons-compress`
+(35 pkgs, broke), `guava` (18 pkgs), `caffeine`, `jspecify`, `failureaccess`,
+`j2objc-annotations`. Today the genuine Guava 33.6.0 and Caffeine 3.2.4 win
+only because resolution *order* happens to place them before the uber JAR —
+order is not a contract, and the Guava skew (31.0.1 vs 33.6.0) is two-plus
+major versions. `org.apache.log4j` is a latent trap of the same kind: the
+log4j2 `log4j-1.2-api` bridge claims the identical package.
+
+## Recommended fix (hybrid)
+
+1. **Central artifacts → normal dependencies.** In `uber-jar-module` (or the
+   `intellij-platform` build script), filter the shade to JetBrains platform
+   code only, e.g.:
+
+       tasks.shadowJar {
+           dependencies {
+               include(dependency("com.jetbrains.intellij.platform:.*"))
+               include(dependency("org.jetbrains.intellij.deps.*:.*"))
+           }
+       }
+
+   and declare the excluded Central artifacts (`guava`, `commons-compress`,
+   `caffeine`, `aalto-xml`, `oro`, `lz4-pure-java`, `automaton`, annotations, …)
+   as `runtime` dependencies in the `fatJar` publication's POM (via
+   `pom.withXml` or a proper component). Pin the versions the IJ POMs declare;
+   Gradle conflict resolution then upgrades them in consumers — which is
+   exactly what fixes the Jib case: 1.26.0 wins *by resolution*, not by
+   classpath order, and the 1.26 API is backward-compatible with 1.21.
+
+2. **JetBrains forks → relocate.** `org.jdom`, `org.apache.log4j`,
+   `gnu.trove`, fastutil classes stay in the shade (declaring
+   them as POM deps would force every consumer to add the JetBrains repo), but
+   get `relocate("org.jdom", "io.spine.tools.ij.jdom")` etc. These are forks —
+   no Central artifact is interchangeable with them, so relocation is the only
+   way to stop them claiming public package names. Keep IntelliJ's own
+   `com.intellij.**` / `org.jetbrains.**` unrelocated: platform code resolves
+   its classes reflectively from string names, and Spine's `psi` / `psi-java`
+   reference them directly.
+
+   **Exception — JNA cannot be relocated.** The `jna`/`jna-platform` fork
+   bundles native `libjnidispatch` binaries whose JNI entry points encode the
+   Java class names literally (`Java_com_sun_jna_Native_...`); relocating
+   `com.sun.jna` breaks the binding with `UnsatisfiedLinkError`. JNA is
+   instead *excluded* from the shade (done, see Log). This is safe: JNA is
+   IntelliJ's OS-integration layer, guarded behind `JnaLoader` and never
+   exercised by headless PSI code — the same category as the pty4j/winp/
+   `bin/**` exclusions already in place. Because the platform classes stay
+   unrelocated, genuine `net.java.dev.jna:jna:5.9.0` from Central is a
+   drop-in if a consumer ever needs the code path (the fork's `5.9.0.26` is
+   upstream 5.9.0 + JetBrains build number). If step 1's POM-dependency
+   machinery lands, JNA can join the declared `runtime` deps instead.
+
+### Alternatives considered
+
+- **Relocate everything** (Guava included): hermetic, but rewrites far more
+  bytecode, risks breaking IntelliJ's reflective service loading, and if any
+  exposed IJ API signature mentions a Guava type, the relocated type leaks
+  into Spine's API. The hybrid keeps relocation confined to the forks.
+- **Thin JAR + JetBrains repositories**: no shading at all; consumers add
+  `intellij-dependencies` / `intellij-repository` to every build. That is the
+  configuration burden the uber JAR exists to avoid — rejected.
+- **Do nothing; document the consumer workaround**: classpath-order pinning
+  must then be replicated (and never "tidied" away) in every consumer, and it
+  cannot protect two colliding *bundled* copies. Rejected.
+
+### Caveats to verify during implementation
+
+- [ ] `psi` / `psi-java` public API does not leak types from the newly
+      relocated fork packages.
+- [ ] IntelliJ 213 code does not reflectively load fork classes by
+      string FQN (grep the platform sources for `"org.jdom`, `"org.apache.log4j`).
+- [ ] The Guava the consumers resolve (33.x) keeps IJ 213 working — IJ uses a
+      narrow, stable Guava surface, but run the `psi`-dependent test suites.
+- [ ] License report / notices still cover the remaining bundled forks.
+
+## Verification
+
+- [ ] `tool-base`: full build; inspect the new JAR — no `com/google/common`,
+      `org/apache/commons/compress`, unrelocated `org/jdom` etc. entries;
+      published POM lists the Central artifacts as `runtime` deps.
+- [ ] Consumer proof: in `delivery-server`, drop the `CommonsCompress`
+      classpath-ordering workaround (`build.gradle.kts`, buildscript block) and
+      the `buildSrc/.../CommonsCompress.kt` declaration, bump the tool
+      versions, and confirm `:delivery-server-cloud-run:jibDockerBuild`
+      succeeds *without* it.
+
+## Log
+
+- 2026-08-12 — drafted from the `delivery-server` incident analysis
+  (PR SpineEventEngine/delivery-server#62, workaround commit `96d489d5`).
+- 2026-08-12 — excluded `com/sun/jna/**` from the `intellij-platform` shade
+  (`intellij-platform/build.gradle.kts`). Measured in `2.0.0-SNAPSHOT.404`:
+  1384 classes + 25 native `jnidispatch` binaries (~3.9 MB) from
+  `org.jetbrains.intellij.deps.jna:jna{,-platform}:5.9.0.26`, entering as
+  `runtime` deps of `com.jetbrains.intellij.platform:util`. Verified
+  `intellij-platform-java` bundles no `com/sun/jna` entries (0) — no change
+  needed there. `com/sun/jna/` is the only `com/sun/*` subtree in the JAR,
+  so the glob cannot over-match.
+- 2026-08-12 (later) — the "no change needed there" conclusion above was
+  wrong: the java JAR was JNA-free only because of the subtraction mechanism
+  (see Analysis). Moved the `com/sun/jna/**` exclusion into the shared
+  `uber-jar-module` list, deleted the verbatim ~120-line duplicate of
+  `excludeFiles()` (and the redundant `tasks.shadowJar` block) from
+  `intellij-platform/build.gradle.kts`, and fixed the dead
+  `resources/com/pti4j/**` typo → `resources/com/pty4j/**` (now actually
+  excludes the pty4j native binaries from the java JAR). Verified:
+  platform / jvm-tool-plugins / protobuf-setup-plugins JAR entry listings
+  identical before vs after; java JAR delta is exactly −1477 `com/sun/jna`
+  entries and −33 `resources/` tree entries (31 pty4j natives + 2 emptied
+  parent dirs), nothing added; 119.1 → 115.1 MB.

--- a/.agents/tasks/unshade-intellij-platform-third-party.md
+++ b/.agents/tasks/unshade-intellij-platform-third-party.md
@@ -193,25 +193,47 @@ merely aligning it, so no future consumer inherits the clash. POM entries:
 86 → 84; `org.jetbrains:annotations` and `annotations-java5` verified to
 survive the artifact-level drop.
 
-### Open — the same defect class remains for 10 other modules
+### POM entries are published non-transitive (2026-08-12)
 
 The flattened POM lists every resolved artifact at *this repo's* version, but
-each listed entry still carries its own transitive graph, which re-requests
-older versions. Resolving the regenerated 84-entry POM in a bare consumer
-with `failOnVersionConflict()` yields 10 conflicting modules:
+each listed entry initially carried its own transitive graph, re-requesting
+older versions. Resolving the 84-entry POM of `intellij-platform-java` in a
+bare consumer with `failOnVersionConflict()` yielded 10 conflicting modules:
 `error_prone_annotations`, `commons-{codec,collections,io,logging}`,
 `kotlin-{stdlib,stdlib-common,reflect}`, `org.jetbrains:annotations`,
-`objenesis`. The standard Spine `forceVersions()` already covers the
-ErrorProne and Kotlin ones; the `commons-*`, `annotations` and `objenesis`
-conflicts are new boilerplate for consumers.
+`objenesis` — new forcing boilerplate for every consumer, which the
+dependency-less POM preceding this task never required.
 
-The dependency-less POM that preceded this task had none of these, so the
-task introduces them. Measured remedy: declare each entry **non-transitive**
-(`<exclusions>` of `*:*`). The published list is already the complete
-flattened closure, so nothing is lost, and each module is then requested at
-exactly one version — the same 84 artifacts resolve with zero conflicts.
-Consumers can still upgrade any entry by ordinary resolution, so the Jib
-`commons-compress` fix is preserved. Not implemented; needs a decision.
+Implemented remedy, after the downstream decision that consumers must not
+force this repo's transitives: `declareUnshadedDependencies` publishes every
+entry with a wildcard `<exclusions>` block (`*:*`), cutting off its
+transitive graph. The published list is already the complete flattened
+closure, so nothing is lost; each module is requested at exactly one version,
+and the same 84 artifacts resolve with **zero** conflicts under
+`failOnVersionConflict()` with no consumer-side forces (measured on the
+regenerated POM). Consumers still upgrade any entry by ordinary resolution,
+so the Jib `commons-compress` fix is preserved. A side benefit: the curation
+is now authoritative — Slf4J, the Kotlin runtime, and the dropped
+groups/modules cannot re-enter through an entry's own POM.
+
+### POM pins align with the Spine-stack versions (2026-08-12)
+
+With the entries non-transitive, the remaining conflict source in a Spine
+consumer is a pin that *disagrees* with what the rest of the consumer's
+graph requests. Measured in `core-jvm-compiler/tests` (strict resolution):
+Jackson `2.13.0` and Caffeine `3.0.4` — the versions the IJ-213 POMs
+request, which stood because this repository never forced these families —
+against `2.21.1`/`3.2.4` requested by the published compiler stack.
+`uber-jar-module.gradle.kts` now forces `Jackson` (2.x), `Jackson.Junior`,
+`Jackson.annotations`, and `Caffeine.lib` in the uber modules' resolution,
+so the published pins become the versions this repository is built and
+tested with (`2.22.1`/`2.22`/`3.2.4`) — the same treatment Guava already
+receives from `forceVersions()`. Caffeine then agrees across the stack with
+no force anywhere; Jackson still skews against artifacts published before
+the stack moved to `2.22.1` (e.g. `compiler-jvm .066` requests `2.21.1` via
+`palantir-java-format`) — that transition-window skew is covered by the
+consumer conventions' `JacksonV2` forces until the stack republishes, and
+disappears entirely once it does.
 - **Subtraction vs Shadow transforms**: the `intellij-platform-java`
   subtraction filter sees pre-transform source paths while the sibling JAR
   stores post-transform ones. `IntelliJUberJar.sourceFormOf()` reverse-maps

--- a/.agents/tasks/unshade-intellij-platform-third-party.md
+++ b/.agents/tasks/unshade-intellij-platform-third-party.md
@@ -303,3 +303,18 @@ identical treatment:
   - `:psi:test` + `:psi-java:test`: 148 passed, 0 failed.
   - Kotlin block comments nest: a literal `META-INF/*.kotlin_module` glob in
     KDoc broke `buildSrc` compilation ("unclosed comment") until rephrased.
+- 2026-08-12 (pre-PR review round) — five reviewers (spine-code-review,
+  kotlin-engineer, review-docs, dependency-audit, gradle-review) all
+  APPROVE after fixes: added `IntelliJUberJarSpec` (7 tests, buildSrc);
+  repaired a dangling KDoc link (`unrelocatedFormOf` → `sourceFormOf`);
+  CC-hardening in `intellij-platform-java` (sibling JAR tracked via
+  `inputs.file` instead of bare `dependsOn` — the up-to-date/build-cache
+  staleness gap is closed; `ArchiveOperations` instead of ambient
+  `Project.zipTree`; `pathsToExclude` is a cleared `Set`). JAR entry
+  listings verified byte-identical before/after the fixes.
+  Measured CC status: `generatePomFileForFatJarPublication` executes under
+  `--configuration-cache`, but the entry is discarded — the `withXml`
+  action's captured `Configuration` is not serializable (a `Provider` of
+  resolution results would be), and the root build script's `gcloud` call
+  is another pre-existing blocker. Full CC-readiness is out of scope; the
+  repository does not enable the configuration cache.

--- a/.agents/tasks/unshade-intellij-platform-third-party.md
+++ b/.agents/tasks/unshade-intellij-platform-third-party.md
@@ -74,15 +74,32 @@ Genuine Maven Central artifacts, bundled unrelocated:
 | Batik + xmlgraphics, `org.imgscalr`, `net.n3.nanoxml`, `it.unimi.dsi` (fastutil classes) | —                         | various                                            |
 
 JetBrains **forks** (published only in the JetBrains `intellij-dependencies`
-repository, *not* Central), also unrelocated:
+repository, *not* Central), also unrelocated. Measured from the resolved
+runtime graphs of both modules (the original table missed that Batik here is
+the JetBrains fork group, and the `intellij-platform-java` graph adds more):
 
-| Fork artifact                                  | Claims package        |
-|------------------------------------------------|-----------------------|
-| `org.jetbrains.intellij.deps:jdom:2.0.6`       | `org.jdom.**`         |
-| `org.jetbrains.intellij.deps:log4j:1.2.17.2`   | `org.apache.log4j.**` |
-| `org.jetbrains.intellij.deps:trove4j`          | `gnu.trove.**`        |
-| `org.jetbrains.intellij.deps.jna:jna-platform` | `com.sun.jna.**`      |
-| `org.jetbrains.intellij.deps.fastutil`         | `it.unimi.dsi.**`     |
+| Fork artifact                                    | Claims package                 | Treatment            |
+|--------------------------------------------------|--------------------------------|----------------------|
+| `org.jetbrains.intellij.deps:jdom:2.0.6`         | `org.jdom.**`                  | relocated            |
+| `org.jetbrains.intellij.deps:log4j:1.2.17.2`     | `org.apache.log4j.**`          | relocated            |
+| `org.jetbrains.intellij.deps:trove4j`            | `gnu.trove.**`                 | relocated            |
+| `org.jetbrains.intellij.deps.fastutil`           | `it.unimi.dsi.**`              | relocated            |
+| `org.jetbrains.intellij.deps.batik:batik-*` (15) | `org.apache.batik.**`          | relocated            |
+| `org.jetbrains.intellij.deps:ion-java`           | `com.amazon.ion.**`            | relocated            |
+| `org.jetbrains.intellij.deps:commons-imaging`    | `org.apache.commons.imaging.**`| relocated            |
+| `org.jetbrains.intellij.deps.jna:jna{,-platform}`| `com.sun.jna.**`               | excluded (JNI names) |
+| `org.jetbrains.intellij.deps.jcef:jcef`          | `org.cef.**`                   | shaded as is (JNI)   |
+| `org.jetbrains.intellij.deps:asm-all`            | `org.jetbrains.org.objectweb`  | shaded as is         |
+| `org.jetbrains.intellij.deps:jb-jdi`, `sa-jdwp`  | `com.jetbrains.{jdi,sa}`       | shaded as is         |
+| `org.jetbrains.intellij.deps:java-compatibility` | `com.intellij.util.ui`         | shaded as is         |
+| coverage/test-discovery/memory agents            | `com.intellij.*`, `org.jetbrains.*` | shaded as is    |
+| `org.jetbrains.intellij:blockmap` (not on Central)| `com.jetbrains.plugin.blockmap`| shaded as is        |
+
+`com.jetbrains.intellij.platform:ide-impl` additionally *vendors* two
+JetBrains-authored classes inside the `io.netty.buffer` package
+(`ByteBufUtf8Writer`, `ByteBufUtilEx`). They have no counterpart in genuine
+Netty, so they are additive, not colliding; artifact-level filtering cannot
+remove them, and they stay.
 
 ### The two IJ fat JARs are a layered pair, not independent bundles
 
@@ -115,6 +132,43 @@ only because resolution *order* happens to place them before the uber JAR —
 order is not a contract, and the Guava skew (31.0.1 vs 33.6.0) is two-plus
 major versions. `org.apache.log4j` is a latent trap of the same kind: the
 log4j2 `log4j-1.2-api` bridge claims the identical package.
+
+## Implemented shape (2026-08-12)
+
+The hybrid fix below is implemented by
+`buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt` — a single
+policy object used by both IJ modules, because the layered pair demands
+identical treatment:
+
+- **Include filter**: only groups `com.jetbrains.intellij(.*)` and
+  `org.jetbrains.intellij(.*)` enter the shade
+  (`ShadowJar.shadeOnlyJetBrainsArtifacts()`).
+- **Relocations** (see the fork table above) under the
+  `io.spine.tools.ij` prefix.
+- **POM generation** (`MavenPublication.declareUnshadedDependencies()`):
+  every resolved runtime artifact outside the shaded and dropped groups
+  becomes a `runtime` dependency; sibling uber modules arriving as project
+  dependencies are declared too (`intellij-platform-java` → `intellij-platform`).
+  Versions are pinned **as resolved in this repo** — i.e. after the Spine
+  version forcing (e.g. Guava `33.6.0-jre`, not IJ's requested `31.0.1-jre`)
+  — which is exactly the combination the repo's own test suites run against.
+  `commons-compress` stays at IJ's `1.21` and upgrades in consumers by
+  resolution, which is the designed fix for the Jib incident.
+- **Dropped groups** (neither shaded nor declared; users add genuine
+  artifacts explicitly if ever needed): `org.jetbrains.kotlin(x)` (provided,
+  as before), `org.jetbrains.pty4j`, `org.jetbrains.jediterm` (terminal),
+  `org.jvnet.winp` (Windows process management; its DLLs were excluded
+  from the old shade anyway).
+- **Central audit**: every POM candidate of both modules verified against
+  `repo1.maven.org` — 85/86 present; the miss (`org.jetbrains.intellij:blockmap`)
+  is shaded instead (self-namespaced package). `marketplace-zip-signer`'s
+  Central POM does not reference `blockmap`, so declaring it is safe.
+- **Subtraction vs Shadow transforms**: the `intellij-platform-java`
+  subtraction filter sees pre-transform source paths while the sibling JAR
+  stores post-transform ones. `IntelliJUberJar.sourceFormOf()` reverse-maps
+  all three transforms (relocated paths, relocated `META-INF/services` file
+  names, `.shadow.kotlin_module` renames); without it the fork classes and
+  metadata duplicate into the java JAR.
 
 ## Recommended fix (hybrid)
 
@@ -175,19 +229,30 @@ log4j2 `log4j-1.2-api` bridge claims the identical package.
 
 ### Caveats to verify during implementation
 
-- [ ] `psi` / `psi-java` public API does not leak types from the newly
-      relocated fork packages.
-- [ ] IntelliJ 213 code does not reflectively load fork classes by
-      string FQN (grep the platform sources for `"org.jdom`, `"org.apache.log4j`).
-- [ ] The Guava the consumers resolve (33.x) keeps IJ 213 working — IJ uses a
-      narrow, stable Guava surface, but run the `psi`-dependent test suites.
-- [ ] License report / notices still cover the remaining bundled forks.
+- [x] `psi` / `psi-java` public API does not leak types from the newly
+      relocated fork packages — no Spine source in this repo imports
+      `org.jdom`, `gnu.trove`, `org.apache.log4j`, `it.unimi`,
+      `org.apache.oro`, `net.jpountz`, or `dk.brics` (grepped 2026-08-12).
+- [x] IntelliJ 213 code does not reflectively load fork classes by string
+      FQN — Shadow rewrites class-name string constants under the relocated
+      prefixes in all shaded bytecode; `psi` / `psi-java` suites pass against
+      the relocated JARs (148 tests). Residual risk: FQNs assembled by
+      concatenation at runtime; none surfaced in tests.
+- [x] The Guava the consumers resolve (33.x) keeps IJ 213 working — the POM
+      pins the repo-resolved `33.6.0-jre`, and this repo's suites have always
+      run IJ 213 against the forced 33.x by construction.
+- [x] License report / notices still cover the remaining bundled forks —
+      the reports enumerate configuration dependencies, which the shade
+      filter does not alter; the full `build` (incl. report regeneration)
+      passes. The regenerated `docs/dependencies/*` changes are version-bump
+      catch-up only.
 
 ## Verification
 
-- [ ] `tool-base`: full build; inspect the new JAR — no `com/google/common`,
-      `org/apache/commons/compress`, unrelocated `org/jdom` etc. entries;
-      published POM lists the Central artifacts as `runtime` deps.
+- [x] `tool-base`: full build passes (241 tasks); both JARs inspected — no
+      `com/google/common`, `org/apache/commons/compress`, unrelocated
+      `org/jdom` etc. entries; generated POMs list the Central artifacts as
+      `runtime` deps (platform: 20, java: 86 incl. the sibling JAR).
 - [ ] Consumer proof: in `delivery-server`, drop the `CommonsCompress`
       classpath-ordering workaround (`build.gradle.kts`, buildscript block) and
       the `buildSrc/.../CommonsCompress.kt` declaration, bump the tool
@@ -218,3 +283,23 @@ log4j2 `log4j-1.2-api` bridge claims the identical package.
   identical before vs after; java JAR delta is exactly −1477 `com/sun/jna`
   entries and −33 `resources/` tree entries (31 pty4j natives + 2 emptied
   parent dirs), nothing added; 119.1 → 115.1 MB.
+- 2026-08-12 (main fix) — implemented the hybrid plan (see "Implemented
+  shape"). New `IntelliJUberJar.kt` policy in `buildSrc`; both IJ module
+  scripts apply the include filter, relocations, and POM generation; dead
+  pty4j / purejavacomm / winp path excludes removed from `uber-jar-module`.
+  Measured results:
+  - `intellij-platform`: 25.8 → **17.4 MB**; POM declares **20** runtime
+    deps (incl. `commons-compress:1.21`, `guava:33.6.0-jre`); zero
+    third-party packages left; relocated trees `io/spine/tools/ij/{jdom
+    (234), log4j (326), trove (457), unimi/dsi (2090), batik (2065)}`.
+  - `intellij-platform-java`: 115.1 → **78.6 MB**; POM declares **86**
+    runtime deps incl. `io.spine.tools:intellij-platform`; relocated
+    `io/spine/tools/ij/{ion (420), imaging (471)}`; jackson/httpclient/
+    xstream/icu4j/gson/… all unbundled into the POM.
+  - Cross-JAR duplicate files: `META-INF/MANIFEST.MF` only (the
+    `sourceFormOf` reverse mapping removed 13 duplicated
+    `.shadow.kotlin_module` files and 2 relocated batik service files
+    discovered during verification).
+  - `:psi:test` + `:psi-java:test`: 148 passed, 0 failed.
+  - Kotlin block comments nest: a literal `META-INF/*.kotlin_module` glob in
+    KDoc broke `buildSrc` compilation ("unclosed comment") until rephrased.

--- a/.agents/tasks/unshade-intellij-platform-third-party.md
+++ b/.agents/tasks/unshade-intellij-platform-third-party.md
@@ -318,3 +318,12 @@ identical treatment:
   resolution results would be), and the root build script's `gcloud` call
   is another pre-existing blocker. Full CC-readiness is out of scope; the
   repository does not enable the configuration cache.
+- 2026-08-12 (PR #188 review) — Codex flagged that flattening every POM
+  dependency to the `runtime` scope leaves the sibling `intellij-platform`
+  (declared `api`) off the compile classpath of a consumer compiling
+  directly against `intellij-platform-java`, whose classes extend platform
+  types. Fixed: project (sibling) dependencies now get the `compile` scope;
+  third-party stays `runtime` — the old zero-dependency POM never offered
+  third-party types at compile scope, and widening that is not this task's
+  goal. Verified: java POM = 1 compile (`intellij-platform`) + 85 runtime;
+  platform POM unchanged (20 runtime).

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -3,10 +3,6 @@
   <component name="Kotlin2JvmCompilerArguments">
     <option name="jvmTarget" value="17" />
   </component>
-  <component name="KotlinCommonCompilerArguments">
-    <option name="apiVersion" value="2.3.21" />
-    <option name="languageVersion" value="2.3.21" />
-  </component>
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
     <option name="version" value="2.3.21" />

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.425"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.425"
+    const val version = "2.0.0-SNAPSHOT.440"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.440"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
@@ -42,7 +42,7 @@ import org.gradle.api.publish.maven.MavenPublication
  * and the bundled copies can no longer shadow genuine artifacts on
  * a consumer's classpath.
  *
- * JetBrains forks which claim the package names of libraries published on
+ * JetBrains forks that claim the package names of libraries published on
  * Maven Central are [relocated][relocations]. They exist only in JetBrains
  * repositories, so declaring them in the POM would force every consumer to
  * add those repositories; relocation removes the collision instead.
@@ -50,7 +50,7 @@ import org.gradle.api.publish.maven.MavenPublication
  * The two uber JARs form a layered pair: `intellij-platform-java` excludes
  * every path already present in the `intellij-platform` JAR. Both modules
  * must therefore apply this policy identically, and the subtraction must
- * account for [relocations] via [unrelocatedFormOf].
+ * account for [relocations] via [sourceFormOf].
  */
 object IntelliJUberJar {
 
@@ -229,11 +229,19 @@ fun ShadowJar.shadeOnlyJetBrainsArtifacts() {
  * The versions are those resolved in this project, i.e. the ones declared
  * by the IntelliJ Platform POMs; consumer projects upgrade them further
  * via the standard Gradle conflict resolution.
+ *
+ * The publication must not declare dependencies of its own, as those created
+ * by `uber-jar-module` do not: this function appends a new `dependencies`
+ * block to the POM without merging into an existing one.
  */
 fun MavenPublication.declareUnshadedDependencies(project: Project) {
+    // Look up the configuration eagerly: the deferred action below must not
+    // capture the `Project` instance. This alone does not make the task
+    // configuration-cache-ready — serializing a `Configuration` is equally
+    // unsupported, and this repository does not enable that cache.
+    val runtimeClasspath = project.configurations.getByName("runtimeClasspath")
     pom.withXml {
         val dependencies = asNode().appendNode("dependencies")
-        val runtimeClasspath = project.configurations.getByName("runtimeClasspath")
         runtimeClasspath.resolvedConfiguration.resolvedArtifacts
             .filter { artifact ->
                 val fromProject =

--- a/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
@@ -269,6 +269,20 @@ fun ShadowJar.shadeOnlyJetBrainsArtifacts() {
  * by the IntelliJ Platform POMs; consumer projects upgrade them further
  * via the standard Gradle conflict resolution.
  *
+ * Every entry is declared with a wildcard `<exclusions>` block, cutting off
+ * its own transitive graph. The declared list is already the complete
+ * flattened runtime closure — each entry's transitives are themselves
+ * entries — so the exclusions lose nothing. Without them, each entry
+ * re-requests its transitives at the version *it* was built against,
+ * older than the resolved version pinned here, and a consumer resolving
+ * with `failOnVersionConflict()` fails on every such disagreement
+ * (measured: 10 conflicting modules, from `commons-io` to `kotlin-stdlib`).
+ * With them, every module is requested at exactly one version, and the POM
+ * resolves conflict-free with no forcing on the consumer side. The flattening
+ * also makes the deliberate curation authoritative: components resolved away
+ * in this project — Slf4J, the Kotlin runtime, the [dropped][IntelliJUberJar]
+ * groups and modules — cannot sneak back in through an entry's own POM.
+ *
  * The publication must not declare dependencies of its own, as those created
  * by `uber-jar-module` do not: this function appends a new `dependencies`
  * block to the POM without merging into an existing one.
@@ -300,6 +314,13 @@ fun MavenPublication.declareUnshadedDependencies(project: Project) {
                     appendNode("artifactId", id.name)
                     appendNode("version", id.version)
                     appendNode("scope", scope)
+                    // The declared list is the complete flattened closure;
+                    // see the function KDoc for why each entry drops its own
+                    // transitive graph.
+                    with(appendNode("exclusions").appendNode("exclusion")) {
+                        appendNode("groupId", "*")
+                        appendNode("artifactId", "*")
+                    }
                 }
             }
     }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
@@ -103,10 +103,24 @@ object IntelliJUberJar {
      * Maven groups deliberately absent from both the shade and the POM.
      *
      * The Kotlin runtime is provided by consumers, as it always was for these
-     * artifacts. The rest is OS-integration machinery — terminal emulation and
-     * Windows process management — never exercised by the headless PSI code.
+     * artifacts. The rest is machinery never exercised by the headless PSI
+     * code: OS integration — terminal emulation and Windows process
+     * management — and the BouncyCastle cryptography stack, reached only from
+     * the remote-development and plugin-signing paths of `ide-impl`.
      * Tool users who need these components add the genuine Central artifacts
      * explicitly; the platform classes reference them by their original names.
+     *
+     * Declaring BouncyCastle would publish a self-contradicting graph, since
+     * the two paths that reach it disagree on the version:
+     *
+     *  - `bcpg-jdk15on:1.69`, via `remote-dev-util`, requires
+     *    `bcprov-jdk15on:1.69`;
+     *  - `marketplace-zip-signer:0.1.3` (see [droppedModules]) requires
+     *    `bcpkix-jdk15on:1.64`, which requires `bcprov-jdk15on:1.64`.
+     *
+     * A consumer resolving with `failOnVersionConflict()` cannot build
+     * against such a POM without forcing a version of its own, which is
+     * exactly the per-consumer boilerplate the POM is meant to remove.
      */
     private val droppedGroups = setOf(
         "org.jetbrains.kotlin",
@@ -114,6 +128,24 @@ object IntelliJUberJar {
         "org.jetbrains.pty4j",
         "org.jetbrains.jediterm",
         "org.jvnet.winp",
+        "org.bouncycastle",
+    )
+
+    /**
+     * Individual artifacts deliberately absent from both the shade and
+     * the POM, identified as `group:name`.
+     *
+     * Unlike [droppedGroups], these belong to groups whose other artifacts
+     * are declared: `org.jetbrains` also holds `annotations`, which consumers
+     * do need.
+     *
+     * `marketplace-zip-signer` signs plugin ZIP archives for the JetBrains
+     * Marketplace. It arrives through `ide-impl`, and headless PSI signs
+     * nothing. Declaring it would also bring the older half of
+     * the BouncyCastle version clash described in [droppedGroups].
+     */
+    private val droppedModules = setOf(
+        "org.jetbrains:marketplace-zip-signer",
     )
 
     /**
@@ -124,11 +156,13 @@ object IntelliJUberJar {
         shadedGroups.any { it.matches(group) }
 
     /**
-     * Tells if the given Maven [group] belongs to the published POM
-     * as a `runtime` dependency.
+     * Tells if the artifact with the given Maven [group] and [name] belongs
+     * to the published POM as a `runtime` dependency.
      */
-    fun isPomDependency(group: String): Boolean =
-        !isShaded(group) && group !in droppedGroups
+    fun isPomDependency(group: String, name: String): Boolean =
+        !isShaded(group)
+                && group !in droppedGroups
+                && "$group:$name" !in droppedModules
 
     /**
      * Applies [relocations] to the given [ShadowJar] task.
@@ -254,7 +288,7 @@ fun MavenPublication.declareUnshadedDependencies(project: Project) {
                 val id = artifact.moduleVersion.id
                 when {
                     fromProject -> id to "compile"
-                    IntelliJUberJar.isPomDependency(id.group) -> id to "runtime"
+                    IntelliJUberJar.isPomDependency(id.group, id.name) -> id to "runtime"
                     else -> null
                 }
             }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.shade
+
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.publish.maven.MavenPublication
+
+/**
+ * The shading policy of the IntelliJ Platform uber-JAR modules
+ * (`intellij-platform` and `intellij-platform-java`).
+ *
+ * Only JetBrains-produced artifacts are welded into the uber JARs.
+ * Third-party components published on Maven Central are not shaded;
+ * they become `runtime` dependencies of the published POM instead, so that
+ * Gradle conflict resolution in consumer projects works on them normally,
+ * and the bundled copies can no longer shadow genuine artifacts on
+ * a consumer's classpath.
+ *
+ * JetBrains forks which claim the package names of libraries published on
+ * Maven Central are [relocated][relocations]. They exist only in JetBrains
+ * repositories, so declaring them in the POM would force every consumer to
+ * add those repositories; relocation removes the collision instead.
+ *
+ * The two uber JARs form a layered pair: `intellij-platform-java` excludes
+ * every path already present in the `intellij-platform` JAR. Both modules
+ * must therefore apply this policy identically, and the subtraction must
+ * account for [relocations] via [unrelocatedFormOf].
+ */
+object IntelliJUberJar {
+
+    /**
+     * Maven groups whose artifacts are welded into the uber JARs.
+     *
+     * These are the IntelliJ Platform itself (`com.jetbrains.intellij.*`),
+     * JetBrains forks of third-party libraries published only in JetBrains
+     * repositories (`org.jetbrains.intellij.deps*`), and auxiliary JetBrains
+     * artifacts absent from Maven Central (`org.jetbrains.intellij`,
+     * e.g. `blockmap`).
+     */
+    private val shadedGroups = listOf(
+        Regex("""com\.jetbrains\.intellij(\..+)?"""),
+        Regex("""org\.jetbrains\.intellij(\..+)?"""),
+    )
+
+    /**
+     * The parent package for the relocated classes of JetBrains forks.
+     */
+    private const val RELOCATION_PREFIX = "io.spine.tools.ij"
+
+    /**
+     * Packages of JetBrains forks that claim the names of libraries published
+     * on Maven Central, mapped to the relocated names.
+     *
+     * Relocation stops the bundled fork classes from clashing with genuine
+     * artifacts on a consumer's classpath. Forks with self-namespaced packages,
+     * such as `asm-all` (`org.jetbrains.org.objectweb.asm`) or `jb-jdi`
+     * (`com.jetbrains.jdi`), need no relocation.
+     *
+     * The JNA fork is deliberately absent: its native `libjnidispatch`
+     * binaries bind JNI entry points to the literal `com.sun.jna` class names,
+     * so relocation would break it. It is excluded from the shade by path
+     * in `uber-jar-module.gradle.kts` instead. The `jcef` fork stays
+     * unrelocated for the same reason: its `org.cef` classes are bound
+     * to CEF native libraries.
+     */
+    private val relocations = mapOf(
+        "org.jdom" to "$RELOCATION_PREFIX.jdom",
+        "org.apache.log4j" to "$RELOCATION_PREFIX.log4j",
+        "gnu.trove" to "$RELOCATION_PREFIX.trove",
+        "it.unimi.dsi" to "$RELOCATION_PREFIX.unimi.dsi",
+        "org.apache.batik" to "$RELOCATION_PREFIX.batik",
+        "com.amazon.ion" to "$RELOCATION_PREFIX.ion",
+        "org.apache.commons.imaging" to "$RELOCATION_PREFIX.imaging",
+    )
+
+    /**
+     * Maven groups deliberately absent from both the shade and the POM.
+     *
+     * The Kotlin runtime is provided by consumers, as it always was for these
+     * artifacts. The rest is OS-integration machinery — terminal emulation and
+     * Windows process management — never exercised by the headless PSI code.
+     * Tool users who need these components add the genuine Central artifacts
+     * explicitly; the platform classes reference them by their original names.
+     */
+    private val droppedGroups = setOf(
+        "org.jetbrains.kotlin",
+        "org.jetbrains.kotlinx",
+        "org.jetbrains.pty4j",
+        "org.jetbrains.jediterm",
+        "org.jvnet.winp",
+    )
+
+    /**
+     * Tells if the artifacts of the given Maven [group] are welded
+     * into the uber JARs.
+     */
+    fun isShaded(group: String): Boolean =
+        shadedGroups.any { it.matches(group) }
+
+    /**
+     * Tells if the given Maven [group] belongs to the published POM
+     * as a `runtime` dependency.
+     */
+    fun isPomDependency(group: String): Boolean =
+        !isShaded(group) && group !in droppedGroups
+
+    /**
+     * Applies [relocations] to the given [ShadowJar] task.
+     */
+    fun relocateForks(task: ShadowJar) {
+        relocations.forEach { (from, to) ->
+            task.relocate(from, to)
+        }
+    }
+
+    /**
+     * Maps an entry path of an already-built uber JAR back to the form Shadow
+     * sees before applying its transformations, returning `null` for paths
+     * Shadow does not transform.
+     *
+     * The subtraction filter of `intellij-platform-java` inspects the entries
+     * of the already-built `intellij-platform` JAR, where Shadow has already
+     * transformed the paths. Shadow evaluates exclusion predicates against
+     * the untransformed source paths, so the subtraction must also exclude
+     * the source form of every transformed entry. Three transformations
+     * apply when relocation is on:
+     *
+     *  1. Classes and resources of [relocated][relocations] packages move
+     *     to the new package path.
+     *  2. `META-INF/services/` files are renamed after the relocated
+     *     service interface.
+     *  3. Kotlin module files (`.kotlin_module`) under `META-INF`
+     *     gain a `.shadow` infix.
+     */
+    fun sourceFormOf(path: String): String? {
+        unrelocatedPathOf(path)?.let {
+            return it
+        }
+        if (path.startsWith(SERVICES_DIR)) {
+            return unrelocatedServiceFileOf(path)
+        }
+        val renamed = ".shadow$KOTLIN_MODULE_EXTENSION"
+        if (path.endsWith(renamed)) {
+            return path.removeSuffix(renamed) + KOTLIN_MODULE_EXTENSION
+        }
+        return null
+    }
+
+    private const val SERVICES_DIR = "META-INF/services/"
+    private const val KOTLIN_MODULE_EXTENSION = ".kotlin_module"
+
+    /**
+     * Reverses transformation 1 of [sourceFormOf]: a slash-separated path
+     * under a relocated package returns to the original package path.
+     */
+    private fun unrelocatedPathOf(path: String): String? {
+        for ((source, target) in relocations) {
+            val targetPath = target.replace('.', '/') + "/"
+            if (path.startsWith(targetPath)) {
+                val sourcePath = source.replace('.', '/') + "/"
+                return sourcePath + path.removePrefix(targetPath)
+            }
+        }
+        return null
+    }
+
+    /**
+     * Reverses transformation 2 of [sourceFormOf]: a service file named after
+     * a relocated interface returns to the name of the original interface.
+     */
+    private fun unrelocatedServiceFileOf(path: String): String? {
+        val serviceName = path.removePrefix(SERVICES_DIR)
+        for ((source, target) in relocations) {
+            if (serviceName.startsWith("$target.")) {
+                return SERVICES_DIR + source + serviceName.removePrefix(target)
+            }
+        }
+        return null
+    }
+}
+
+/**
+ * Restricts the shade to JetBrains-produced artifacts and relocates
+ * the JetBrains forks claiming public package names.
+ *
+ * Artifacts outside the [shaded groups][IntelliJUberJar.isShaded] do not
+ * enter the JAR. Those of them available on Maven Central are declared as
+ * POM `runtime` dependencies via [declareUnshadedDependencies].
+ */
+fun ShadowJar.shadeOnlyJetBrainsArtifacts() {
+    dependencies {
+        include { IntelliJUberJar.isShaded(it.moduleGroup) }
+    }
+    IntelliJUberJar.relocateForks(this)
+}
+
+/**
+ * Declares the artifacts of the module's runtime classpath that are not
+ * welded into the uber JAR as `runtime` dependencies of the published POM.
+ *
+ * Dependencies on sibling uber-JAR modules, arriving as project dependencies,
+ * are declared as well, preserving the link between the layered JARs.
+ * The versions are those resolved in this project, i.e. the ones declared
+ * by the IntelliJ Platform POMs; consumer projects upgrade them further
+ * via the standard Gradle conflict resolution.
+ */
+fun MavenPublication.declareUnshadedDependencies(project: Project) {
+    pom.withXml {
+        val dependencies = asNode().appendNode("dependencies")
+        val runtimeClasspath = project.configurations.getByName("runtimeClasspath")
+        runtimeClasspath.resolvedConfiguration.resolvedArtifacts
+            .filter { artifact ->
+                val fromProject =
+                    artifact.id.componentIdentifier is ProjectComponentIdentifier
+                fromProject || IntelliJUberJar.isPomDependency(artifact.moduleVersion.id.group)
+            }
+            .map { it.moduleVersion.id }
+            .distinctBy { "${it.group}:${it.name}" }
+            .sortedBy { "${it.group}:${it.name}" }
+            .forEach { id ->
+                with(dependencies.appendNode("dependency")) {
+                    appendNode("groupId", id.group)
+                    appendNode("artifactId", id.name)
+                    appendNode("version", id.version)
+                    appendNode("scope", "runtime")
+                }
+            }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/shade/IntelliJUberJar.kt
@@ -222,10 +222,15 @@ fun ShadowJar.shadeOnlyJetBrainsArtifacts() {
 
 /**
  * Declares the artifacts of the module's runtime classpath that are not
- * welded into the uber JAR as `runtime` dependencies of the published POM.
+ * welded into the uber JAR as dependencies of the published POM.
  *
  * Dependencies on sibling uber-JAR modules, arriving as project dependencies,
- * are declared as well, preserving the link between the layered JARs.
+ * receive the `compile` scope: the classes of this JAR compile against the
+ * classes of the sibling, so a consumer compiling directly against this
+ * artifact needs the sibling on the compile classpath, too. Third-party
+ * artifacts receive the `runtime` scope, which serves the purpose of their
+ * declaration — correct runtime resolution — without widening the compile
+ * classpath beyond what the previously dependency-less POM provided.
  * The versions are those resolved in this project, i.e. the ones declared
  * by the IntelliJ Platform POMs; consumer projects upgrade them further
  * via the standard Gradle conflict resolution.
@@ -243,20 +248,24 @@ fun MavenPublication.declareUnshadedDependencies(project: Project) {
     pom.withXml {
         val dependencies = asNode().appendNode("dependencies")
         runtimeClasspath.resolvedConfiguration.resolvedArtifacts
-            .filter { artifact ->
+            .mapNotNull { artifact ->
                 val fromProject =
                     artifact.id.componentIdentifier is ProjectComponentIdentifier
-                fromProject || IntelliJUberJar.isPomDependency(artifact.moduleVersion.id.group)
+                val id = artifact.moduleVersion.id
+                when {
+                    fromProject -> id to "compile"
+                    IntelliJUberJar.isPomDependency(id.group) -> id to "runtime"
+                    else -> null
+                }
             }
-            .map { it.moduleVersion.id }
-            .distinctBy { "${it.group}:${it.name}" }
-            .sortedBy { "${it.group}:${it.name}" }
-            .forEach { id ->
+            .distinctBy { (id, _) -> "${id.group}:${id.name}" }
+            .sortedBy { (id, _) -> "${id.group}:${id.name}" }
+            .forEach { (id, scope) ->
                 with(dependencies.appendNode("dependency")) {
                     appendNode("groupId", id.group)
                     appendNode("artifactId", id.name)
                     appendNode("version", id.version)
-                    appendNode("scope", "runtime")
+                    appendNode("scope", scope)
                 }
             }
     }

--- a/buildSrc/src/main/kotlin/uber-jar-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/uber-jar-module.gradle.kts
@@ -150,18 +150,6 @@ private fun ShadowJar.excludeFiles() {
         "windows/**",
         "xml/**",
 
-        /*
-          Exclude the native binaries of `https://github.com/JetBrains/pty4j`.
-          We don't need the terminal.
-         */
-        "resources/com/pty4j/**",
-
-        /* Exclude the IntelliJ fork of
-          `http://www.sparetimelabs.com/purejavacomm/purejavacomm.php`.
-           It is the part of the IDEA's terminal implementation.
-         */
-        "purejavacomm/**",
-
         /* Exclude IDEA project templates. */
         "resources/projectTemplates/**",
 
@@ -193,13 +181,6 @@ private fun ShadowJar.excludeFiles() {
          */
         "win32-x86/**",
         "win32-x86-64/**",
-
-        /**
-         * Exclude the Windows process management (WinP) libraries.
-         * See: `https://github.com/jenkinsci/winp`.
-         */
-        "winp.dll",
-        "winp.x64.dll",
 
         /*
           Exclude the JetBrains fork of JNA (`org.jetbrains.intellij.deps.jna`),

--- a/buildSrc/src/main/kotlin/uber-jar-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/uber-jar-module.gradle.kts
@@ -27,6 +27,8 @@
 @file:Suppress("UnstableApiUsage") // `configurations` block.
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import io.spine.dependency.lib.Caffeine
+import io.spine.dependency.lib.Jackson
 import io.spine.gradle.publish.IncrementGuard
 import io.spine.gradle.publish.SpinePublishing
 import io.spine.gradle.publish.setup
@@ -43,6 +45,29 @@ plugins {
 }
 apply<IncrementGuard>()
 LicenseReporter.generateReportIn(project)
+
+/*
+ * Align third-party components shared with the rest of the Spine stack
+ * to the versions this repository is built and tested with.
+ *
+ * The versions resolved here become the pins of the published POM entries
+ * (see `declareUnshadedDependencies`). Without this block, the versions
+ * requested by the IntelliJ Platform POMs stand — e.g. Jackson `2.13.0`,
+ * Caffeine `3.0.4` — and every consumer resolving with
+ * `failOnVersionConflict()` fails on the disagreement with the versions
+ * the rest of its graph requests. Guava and other components covered by
+ * `forceVersions()` of the `module` plugin are aligned the same way already.
+ */
+configurations.all {
+    resolutionStrategy {
+        Jackson.forceArtifacts(project, this@all, this@resolutionStrategy)
+        Jackson.Junior.forceArtifacts(project, this@all, this@resolutionStrategy)
+        force(
+            Jackson.annotations,
+            Caffeine.lib,
+        )
+    }
+}
 
 spinePublishing {
     // This prefix does not apply to the modules of this project because they all belong

--- a/buildSrc/src/main/kotlin/uber-jar-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/uber-jar-module.gradle.kts
@@ -151,10 +151,10 @@ private fun ShadowJar.excludeFiles() {
         "xml/**",
 
         /*
-          Exclude `https://github.com/JetBrains/pty4j`.
+          Exclude the native binaries of `https://github.com/JetBrains/pty4j`.
           We don't need the terminal.
          */
-        "resources/com/pti4j/**",
+        "resources/com/pty4j/**",
 
         /* Exclude the IntelliJ fork of
           `http://www.sparetimelabs.com/purejavacomm/purejavacomm.php`.
@@ -200,5 +200,21 @@ private fun ShadowJar.excludeFiles() {
          */
         "winp.dll",
         "winp.x64.dll",
+
+        /*
+          Exclude the JetBrains fork of JNA (`org.jetbrains.intellij.deps.jna`),
+          which arrives transitively with the IntelliJ Platform artifacts.
+          Despite the `com.sun.jna` package, JNA is not part of the JDK, and
+          the unrelocated classes would shadow the genuine `net.java.dev.jna`
+          artifacts on a consumer's classpath. The headless PSI code does not
+          use this OS-integration layer. Should the tool users need JNA, they
+          would add `net.java.dev.jna:jna:5.9.0` (a drop-in) explicitly.
+
+          This entry must stay in the shared list: `intellij-platform-java`
+          excludes whatever the `intellij-platform` JAR already contains, so
+          an exclusion made only in one module resurfaces the files in the
+          other module's JAR.
+         */
+        "com/sun/jna/**",
     )
 }

--- a/buildSrc/src/test/kotlin/io/spine/gradle/shade/IntelliJUberJarSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/shade/IntelliJUberJarSpec.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.shade
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`IntelliJUberJar` should")
+internal class IntelliJUberJarSpec {
+
+    @Test
+    fun `shade JetBrains groups`() {
+        IntelliJUberJar.isShaded("com.jetbrains.intellij.platform") shouldBe true
+        IntelliJUberJar.isShaded("com.jetbrains.intellij.java") shouldBe true
+        IntelliJUberJar.isShaded("org.jetbrains.intellij.deps") shouldBe true
+        IntelliJUberJar.isShaded("org.jetbrains.intellij.deps.jna") shouldBe true
+        IntelliJUberJar.isShaded("org.jetbrains.intellij.deps.batik") shouldBe true
+        // The group of `blockmap`, which is absent from Maven Central.
+        IntelliJUberJar.isShaded("org.jetbrains.intellij") shouldBe true
+    }
+
+    @Test
+    fun `not shade third-party groups`() {
+        IntelliJUberJar.isShaded("org.jdom") shouldBe false
+        IntelliJUberJar.isShaded("com.google.guava") shouldBe false
+        IntelliJUberJar.isShaded("org.jetbrains.kotlin") shouldBe false
+        IntelliJUberJar.isShaded("org.jetbrains.pty4j") shouldBe false
+        // The group of `org.jetbrains:annotations` is not `org.jetbrains.intellij`.
+        IntelliJUberJar.isShaded("org.jetbrains") shouldBe false
+        // The group regexes are anchored: a lookalike prefix does not match.
+        IntelliJUberJar.isShaded("com.jetbrains.intellijoid") shouldBe false
+    }
+
+    @Test
+    fun `declare only unshaded, non-dropped groups in the POM`() {
+        IntelliJUberJar.isPomDependency("com.google.guava") shouldBe true
+        IntelliJUberJar.isPomDependency("org.apache.commons") shouldBe true
+        IntelliJUberJar.isPomDependency("org.jdom") shouldBe true
+
+        // Shaded groups do not belong to the POM.
+        IntelliJUberJar.isPomDependency("com.jetbrains.intellij.platform") shouldBe false
+        IntelliJUberJar.isPomDependency("org.jetbrains.intellij.deps") shouldBe false
+
+        // Deliberately dropped groups do not belong to the POM either.
+        IntelliJUberJar.isPomDependency("org.jetbrains.kotlin") shouldBe false
+        IntelliJUberJar.isPomDependency("org.jetbrains.kotlinx") shouldBe false
+        IntelliJUberJar.isPomDependency("org.jetbrains.pty4j") shouldBe false
+        IntelliJUberJar.isPomDependency("org.jetbrains.jediterm") shouldBe false
+        IntelliJUberJar.isPomDependency("org.jvnet.winp") shouldBe false
+    }
+
+    @Test
+    fun `map a relocated class path back to its source form`() {
+        IntelliJUberJar.sourceFormOf("io/spine/tools/ij/jdom/Element.class") shouldBe
+                "org/jdom/Element.class"
+        IntelliJUberJar.sourceFormOf("io/spine/tools/ij/log4j/Logger.class") shouldBe
+                "org/apache/log4j/Logger.class"
+        IntelliJUberJar.sourceFormOf(
+            "io/spine/tools/ij/unimi/dsi/fastutil/ints/IntList.class"
+        ) shouldBe "it/unimi/dsi/fastutil/ints/IntList.class"
+    }
+
+    @Test
+    fun `map a renamed service file back to its source form`() {
+        IntelliJUberJar.sourceFormOf(
+            "META-INF/services/io.spine.tools.ij.batik.ext.awt.image.spi.ImageWriter"
+        ) shouldBe "META-INF/services/org.apache.batik.ext.awt.image.spi.ImageWriter"
+    }
+
+    @Test
+    fun `map a renamed Kotlin module file back to its source form`() {
+        IntelliJUberJar.sourceFormOf("META-INF/intellij.platform.core.shadow.kotlin_module")
+            .shouldBe("META-INF/intellij.platform.core.kotlin_module")
+    }
+
+    @Test
+    fun `return 'null' for paths Shadow does not transform`() {
+        IntelliJUberJar.sourceFormOf("com/intellij/psi/PsiFile.class") shouldBe null
+        IntelliJUberJar.sourceFormOf("META-INF/MANIFEST.MF") shouldBe null
+        // A service file of an interface outside the relocated packages.
+        IntelliJUberJar.sourceFormOf(
+            "META-INF/services/org.codehaus.stax2.XMLInputFactory2"
+        ) shouldBe null
+        // A Kotlin module file that was not renamed.
+        IntelliJUberJar.sourceFormOf("META-INF/blockmap.kotlin_module") shouldBe null
+    }
+}

--- a/buildSrc/src/test/kotlin/io/spine/gradle/shade/IntelliJUberJarSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/shade/IntelliJUberJarSpec.kt
@@ -58,20 +58,36 @@ internal class IntelliJUberJarSpec {
 
     @Test
     fun `declare only unshaded, non-dropped groups in the POM`() {
-        IntelliJUberJar.isPomDependency("com.google.guava") shouldBe true
-        IntelliJUberJar.isPomDependency("org.apache.commons") shouldBe true
-        IntelliJUberJar.isPomDependency("org.jdom") shouldBe true
+        IntelliJUberJar.isPomDependency("com.google.guava", "guava") shouldBe true
+        IntelliJUberJar.isPomDependency("org.apache.commons", "commons-compress") shouldBe true
+        IntelliJUberJar.isPomDependency("org.jdom", "jdom") shouldBe true
 
         // Shaded groups do not belong to the POM.
-        IntelliJUberJar.isPomDependency("com.jetbrains.intellij.platform") shouldBe false
-        IntelliJUberJar.isPomDependency("org.jetbrains.intellij.deps") shouldBe false
+        IntelliJUberJar.isPomDependency("com.jetbrains.intellij.platform", "ide-impl") shouldBe
+                false
+        IntelliJUberJar.isPomDependency("org.jetbrains.intellij.deps", "jdom") shouldBe false
 
         // Deliberately dropped groups do not belong to the POM either.
-        IntelliJUberJar.isPomDependency("org.jetbrains.kotlin") shouldBe false
-        IntelliJUberJar.isPomDependency("org.jetbrains.kotlinx") shouldBe false
-        IntelliJUberJar.isPomDependency("org.jetbrains.pty4j") shouldBe false
-        IntelliJUberJar.isPomDependency("org.jetbrains.jediterm") shouldBe false
-        IntelliJUberJar.isPomDependency("org.jvnet.winp") shouldBe false
+        IntelliJUberJar.isPomDependency("org.jetbrains.kotlin", "kotlin-stdlib") shouldBe false
+        IntelliJUberJar.isPomDependency("org.jetbrains.kotlinx", "kotlinx-serialization-core-jvm")
+            .shouldBe(false)
+        IntelliJUberJar.isPomDependency("org.jetbrains.pty4j", "pty4j") shouldBe false
+        IntelliJUberJar.isPomDependency("org.jetbrains.jediterm", "jediterm-core") shouldBe false
+        IntelliJUberJar.isPomDependency("org.jvnet.winp", "winp") shouldBe false
+
+        // The BouncyCastle stack is dropped as a whole, so that the POM does not
+        // carry the `1.69` vs. `1.64` clash of its two entry points.
+        IntelliJUberJar.isPomDependency("org.bouncycastle", "bcpg-jdk15on") shouldBe false
+        IntelliJUberJar.isPomDependency("org.bouncycastle", "bcprov-jdk15on") shouldBe false
+        IntelliJUberJar.isPomDependency("org.bouncycastle", "bcpkix-jdk15on") shouldBe false
+    }
+
+    @Test
+    fun `drop an individual artifact, keeping the rest of its group`() {
+        IntelliJUberJar.isPomDependency("org.jetbrains", "marketplace-zip-signer") shouldBe false
+
+        // The group of the dropped artifact stays declarable.
+        IntelliJUberJar.isPomDependency("org.jetbrains", "annotations") shouldBe true
     }
 
     @Test

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -859,14 +859,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -1776,14 +1776,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -2245,14 +2245,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:38 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3114,14 +3114,14 @@ This report was generated on **Wed Aug 12 22:42:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -3132,7 +3132,7 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
      * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.4.
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.2.4.
      * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3330,45 +3330,41 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
      * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.22.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.5.1.
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 7.2.0.
      * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.4.
-     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.2.4.
      * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3752,10 +3748,10 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.3.0.
      * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+     * **License:** [The BSD 2-Clause License](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
      * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
@@ -4206,14 +4202,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4235,36 +4231,36 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
      * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.0.
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.13.0.
-     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.22.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.13.0.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.13.0.
-     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.22.1.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.jr. **Name** : jackson-jr-objects. **Version** : 2.13.0.
-     * **Project URL:** [http://wiki.fasterxml.com/JacksonHome](http://wiki.fasterxml.com/JacksonHome)
+1.  **Group** : com.fasterxml.jackson.jr. **Name** : jackson-jr-objects. **Version** : 2.22.1.
+     * **Project URL:** [https://github.com/FasterXML/jackson-jr](https://github.com/FasterXML/jackson-jr)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.13.0.
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.4.
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.2.4.
      * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -4790,74 +4786,46 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
      * **Project URL:** [https://github.com/FasterXML/aalto-xml](https://github.com/FasterXML/aalto-xml)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.0.
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
-     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.13.0.
-     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.22.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.13.0.
-     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.13.0.
-     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.jr. **Name** : jackson-jr-objects. **Version** : 2.13.0.
-     * **Project URL:** [http://wiki.fasterxml.com/JacksonHome](http://wiki.fasterxml.com/JacksonHome)
+1.  **Group** : com.fasterxml.jackson.jr. **Name** : jackson-jr-objects. **Version** : 2.22.1.
+     * **Project URL:** [https://github.com/FasterXML/jackson-jr](https://github.com/FasterXML/jackson-jr)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.13.0.
-     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
-     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.5.1.
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 7.2.0.
      * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.4.
-     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
-     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.2.4.
      * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5458,10 +5426,10 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.3.0.
      * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+     * **License:** [The BSD 2-Clause License](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
      * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
@@ -5996,14 +5964,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:27 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:40 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6086,41 +6054,41 @@ This report was generated on **Wed Aug 12 22:42:27 WEST 2026** using
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ## Compile, tests, and tooling
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.22.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.5.1.
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 7.2.0.
      * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.2.4.
      * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -6462,10 +6430,10 @@ This report was generated on **Wed Aug 12 22:42:27 WEST 2026** using
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](https://opensource.org/licenses/MIT)
 
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.3.0.
      * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+     * **License:** [The BSD 2-Clause License](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
      * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
@@ -6857,14 +6825,14 @@ This report was generated on **Wed Aug 12 22:42:27 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
@@ -7635,14 +7603,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8504,14 +8472,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.11.1.
@@ -9477,14 +9445,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9579,41 +9547,41 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ## Compile, tests, and tooling
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.22.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.3.
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.22.1.
      * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.5.1.
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 7.2.0.
      * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.2.4.
      * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -9963,10 +9931,10 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](https://opensource.org/licenses/MIT)
 
-1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.3.0.
      * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
+     * **License:** [The BSD 2-Clause License](http://www.opensource.org/licenses/bsd-license.php)
 
 1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
      * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
@@ -10358,14 +10326,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -11477,14 +11445,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -13310,14 +13278,14 @@ This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:27 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:40 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.410`
+# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14228,6 +14196,6 @@ This report was generated on **Wed Aug 12 22:42:27 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:19:40 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -859,14 +859,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -1776,14 +1776,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -2245,14 +2245,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:24 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3114,14 +3114,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4206,14 +4206,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5996,14 +5996,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:06 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6857,14 +6857,14 @@ This report was generated on **Mon Jul 20 13:42:06 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
@@ -7635,14 +7635,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8504,14 +8504,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.11.1.
@@ -9477,14 +9477,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10358,14 +10358,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -11477,14 +11477,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -13310,14 +13310,14 @@ This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:06 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.404`
+# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14228,6 +14228,6 @@ This report was generated on **Mon Jul 20 13:42:06 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 20 13:42:05 WEST 2026** using 
+This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:classic-codegen:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -859,14 +859,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:gradle-plugin-api:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -1776,14 +1776,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:gradle-plugin-api-test-fixtures:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -2245,14 +2245,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:38 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:gradle-root-plugin:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3114,14 +3114,14 @@ This report was generated on **Wed Aug 12 23:19:38 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:intellij-platform:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -4202,14 +4202,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -5964,14 +5964,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:40 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:jvm-tool-plugins:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6825,14 +6825,14 @@ This report was generated on **Wed Aug 12 23:19:40 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:jvm-tools:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
@@ -7603,14 +7603,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:plugin-base:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8472,14 +8472,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:plugin-testlib:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.11.1.
@@ -9445,14 +9445,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:protobuf-setup-plugins:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10326,14 +10326,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:psi:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -11445,14 +11445,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:psi-java:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : be.cyberelf.nanoxml. **Name** : nanoxml. **Version** : 2.2.3.
@@ -13278,14 +13278,14 @@ This report was generated on **Wed Aug 12 23:19:39 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:40 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.412`
+# Dependencies of `io.spine.tools:tool-base:2.0.0-SNAPSHOT.410`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14196,6 +14196,6 @@ This report was generated on **Wed Aug 12 23:19:40 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 23:19:40 WEST 2026** using 
+This report was generated on **Wed Aug 12 23:26:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -859,7 +859,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1776,7 +1776,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2245,7 +2245,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:24 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:25 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3114,7 +3114,7 @@ This report was generated on **Wed Aug 12 19:30:24 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4206,7 +4206,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5996,7 +5996,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:27 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6857,7 +6857,7 @@ This report was generated on **Wed Aug 12 19:30:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7635,7 +7635,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8504,7 +8504,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9477,7 +9477,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10358,7 +10358,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11477,7 +11477,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -13310,7 +13310,7 @@ This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:26 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:27 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -14228,6 +14228,6 @@ This report was generated on **Wed Aug 12 19:30:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 12 19:30:25 WEST 2026** using 
+This report was generated on **Wed Aug 12 22:42:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -423,6 +423,11 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>abi-tools</artifactId>
+    <version>2.3.21</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-assignment-compiler-plugin-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
@@ -434,6 +439,11 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-build-tools-impl</artifactId>
+    <version>2.3.21</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
   <dependency>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.412</version>
+<version>2.0.0-SNAPSHOT.410</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.404</version>
+<version>2.0.0-SNAPSHOT.410</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -176,7 +176,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.425</version>
+    <version>2.0.0-SNAPSHOT.440</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -423,6 +423,11 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>abi-tools</artifactId>
+    <version>2.3.21</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-assignment-compiler-plugin-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
@@ -434,6 +439,11 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-build-tools-impl</artifactId>
+    <version>2.3.21</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
   <dependency>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -423,11 +423,6 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
-    <artifactId>abi-tools</artifactId>
-    <version>2.3.21</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-assignment-compiler-plugin-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
@@ -439,11 +434,6 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-build-tools-impl</artifactId>
-    <version>2.3.21</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.kotlin</groupId>
-    <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
     <version>2.3.21</version>
   </dependency>
   <dependency>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>tool-base</artifactId>
-<version>2.0.0-SNAPSHOT.410</version>
+<version>2.0.0-SNAPSHOT.412</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/intellij-platform-java/build.gradle.kts
+++ b/intellij-platform-java/build.gradle.kts
@@ -28,6 +28,7 @@ import io.spine.dependency.lib.IntelliJ
 import io.spine.gradle.shade.IntelliJUberJar
 import io.spine.gradle.shade.declareUnshadedDependencies
 import io.spine.gradle.shade.shadeOnlyJetBrainsArtifacts
+import org.gradle.kotlin.dsl.support.serviceOf
 
 plugins {
     `uber-jar-module`
@@ -142,12 +143,18 @@ dependencies {
 tasks.shadowJar {
     shadeOnlyJetBrainsArtifacts()
     val platformJarTask = intellijPlatformModule.tasks.shadowJar
-    dependsOn(platformJarTask)
-    val pathsToExclude = mutableListOf<String>()
+    // Track the sibling JAR as an input, so that a change in its content
+    // re-runs this task. The provider also carries the task dependency.
+    inputs.file(platformJarTask.flatMap { it.archiveFile })
+        .withPropertyName("intellijPlatformJar")
+        .withPathSensitivity(PathSensitivity.NONE)
+    val archiveOperations = serviceOf<ArchiveOperations>()
+    val pathsToExclude = mutableSetOf<String>()
     doFirst {
+        pathsToExclude.clear()
         // The path to the file produced for `intellij-platform` module.
         val jarPath = platformJarTask.get().archiveFile.get().asFile
-        zipTree(jarPath).visit {
+        archiveOperations.zipTree(jarPath).visit {
             if (!isDirectory) {
                 pathsToExclude.add(this.path)
                 IntelliJUberJar.sourceFormOf(this.path)?.let {

--- a/intellij-platform-java/build.gradle.kts
+++ b/intellij-platform-java/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,9 @@
  */
 
 import io.spine.dependency.lib.IntelliJ
+import io.spine.gradle.shade.IntelliJUberJar
+import io.spine.gradle.shade.declareUnshadedDependencies
+import io.spine.gradle.shade.shadeOnlyJetBrainsArtifacts
 
 plugins {
     `uber-jar-module`
@@ -130,8 +133,14 @@ dependencies {
 
 /**
  * Exclude files from `intellij-platform` fat JAR when packing fat JAR for this module.
+ *
+ * The sibling JAR stores Shadow-transformed entries — relocated fork classes,
+ * renamed service files and Kotlin module files — under their new paths, while
+ * the exclusion predicate below sees the untransformed source paths, so every
+ * transformed entry is subtracted in its source form as well.
  */
 tasks.shadowJar {
+    shadeOnlyJetBrainsArtifacts()
     val platformJarTask = intellijPlatformModule.tasks.shadowJar
     dependsOn(platformJarTask)
     val pathsToExclude = mutableListOf<String>()
@@ -141,10 +150,19 @@ tasks.shadowJar {
         zipTree(jarPath).visit {
             if (!isDirectory) {
                 pathsToExclude.add(this.path)
+                IntelliJUberJar.sourceFormOf(this.path)?.let {
+                    pathsToExclude.add(it)
+                }
             }
         }
-    }                                                               
+    }
     exclude {
         it.path in pathsToExclude
+    }
+}
+
+publishing {
+    publications.named<MavenPublication>("fatJar") {
+        declareUnshadedDependencies(project)
     }
 }

--- a/intellij-platform/build.gradle.kts
+++ b/intellij-platform/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import io.spine.dependency.lib.IntelliJ
 import io.spine.dependency.lib.Kotlin
 import io.spine.gradle.report.license.LicenseReporter
@@ -35,122 +34,6 @@ plugins {
 LicenseReporter.generateReportIn(project)
 
 description = "Core IntelliJ Platform services and language-neutral utils"
-
-tasks.shadowJar {
-    excludeFiles()
-    isZip64 = true  /* The archive has way too many items. So using the Zip64 mode. */
-}
-
-/**
- * Exclude unwanted directories.
- */
-private fun ShadowJar.excludeFiles() {
-    exclude(
-        /*
-          Exclude IntelliJ Platform images and other resources associated with IntelliJ UI.
-          We do not call the UI, so they won't be used.
-         */
-        "actions/**",
-        "chooser/**",
-        "codeStyle/**",
-        "codeStylePreview/**",
-        "codeWithMe/**",
-        "darcula/**",
-        "debugger/**",
-        "diff/**",
-        "duplicates/**",
-        "expui/**",
-        "extensions/**",
-        "fileTemplates/**",
-        "fileTypes/**",
-        "general/**",
-        "graph/**",
-        "gutter/**",
-        "hierarchy/**",
-        "icons/**",
-        "ide/**",
-        "idea/**",
-        "inlayProviders/**",
-        "inspectionDescriptions/**",
-        "inspectionReport/**",
-        "intentionDescriptions/**",
-        "javadoc/**",
-        "javaee/**",
-        "json/**",
-        "liveTemplates/**",
-        "mac/**",
-        "modules/**",
-        "nodes/**",
-        "objectBrowser/**",
-        "plugins/**",
-        "postfixTemplates/**",
-        "preferences/**",
-        "process/**",
-        "providers/**",
-        "runConfigurations/**",
-        "scope/**",
-        "search/**",
-        "toolbar/**",
-        "toolbarDecorator/**",
-        "toolwindows/**",
-        "vcs/**",
-        "webreferences/**",
-        "welcome/**",
-        "windows/**",
-        "xml/**",
-
-        /*
-          Exclude `https://github.com/JetBrains/pty4j`.
-          We don't need the terminal.
-         */
-        "resources/com/pti4j/**",
-
-        /* Exclude the IntelliJ fork of
-          `http://www.sparetimelabs.com/purejavacomm/purejavacomm.php`.
-           It is the part of the IDEA's terminal implementation.
-         */
-        "purejavacomm/**",
-
-        /* Exclude IDEA project templates. */
-        "resources/projectTemplates/**",
-
-        /*
-          Exclude dynamic libraries. Should the tool users need them,
-          they would add them explicitly.
-         */
-        "bin/**",
-
-        /*
-          Exclude Google Protobuf definitions to avoid duplicates.
-         */
-        "google/**",
-        "src/google/**",
-
-        /**
-         * Exclude Spine Protobuf definitions to avoid duplications.
-         */
-        "spine/**",
-
-        /**
-         * Exclude Kotlin runtime because it will be provided.
-         */
-        "kotlin/**",
-        "kotlinx/**",
-
-        /**
-         * Exclude native libraries related to debugging.
-         */
-        "win32-x86/**",
-        "win32-x86-64/**",
-
-        /**
-         * Exclude the Windows process management (WinP) libraries.
-         * See: `https://github.com/jenkinsci/winp`.
-         */
-        "winp.dll",
-        "winp.x64.dll",
-    )
-}
 
 dependencies {
     IntelliJ.Platform.run {

--- a/intellij-platform/build.gradle.kts
+++ b/intellij-platform/build.gradle.kts
@@ -27,6 +27,8 @@
 import io.spine.dependency.lib.IntelliJ
 import io.spine.dependency.lib.Kotlin
 import io.spine.gradle.report.license.LicenseReporter
+import io.spine.gradle.shade.declareUnshadedDependencies
+import io.spine.gradle.shade.shadeOnlyJetBrainsArtifacts
 
 plugins {
     `uber-jar-module`
@@ -34,6 +36,16 @@ plugins {
 LicenseReporter.generateReportIn(project)
 
 description = "Core IntelliJ Platform services and language-neutral utils"
+
+tasks.shadowJar {
+    shadeOnlyJetBrainsArtifacts()
+}
+
+publishing {
+    publications.named<MavenPublication>("fatJar") {
+        declareUnshadedDependencies(project)
+    }
+}
 
 dependencies {
     IntelliJ.Platform.run {

--- a/tool-base/src/main/java/io/spine/tools/code/Line.java
+++ b/tool-base/src/main/java/io/spine/tools/code/Line.java
@@ -74,7 +74,8 @@ public class Line implements Element{
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o instanceof Line other && text.equals(other.text);
+        return (this == o)
+                || ((o instanceof Line other) && text.equals(other.text));
     }
 
     @Override

--- a/tool-base/src/main/java/io/spine/tools/fs/ExternalModules.java
+++ b/tool-base/src/main/java/io/spine/tools/fs/ExternalModules.java
@@ -101,7 +101,8 @@ public final class ExternalModules {
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o instanceof ExternalModules other && modules.equals(other.modules);
+        return (this == o) ||
+                ((o instanceof ExternalModules other) && modules.equals(other.modules));
     }
 
     @Override

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.404")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.410")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.410")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.412")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.412")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.410")


### PR DESCRIPTION
## Why

In `delivery-server`, `jibDockerBuild` failed with a `NoSuchMethodError` in `commons-compress`: the `intellij-platform` fat JAR bundles **575 packages of unrelocated third-party classes** (Guava 31, commons-compress 1.21, Caffeine, Netty, …) that reach consumers' buildscript classpaths and shadow genuine artifacts by classloader order. No version constraint or BOM can fix it — the shaded copies are not dependencies, they are bytecode inside another artifact. See `.agents/tasks/unshade-intellij-platform-third-party.md` for the full incident analysis.

## What

A single shading policy (`buildSrc/.../shade/IntelliJUberJar.kt`) applied identically to `intellij-platform` and `intellij-platform-java` (they form a layered pair — the java JAR subtracts the platform JAR's contents at build time):

- **Include filter**: only JetBrains groups (`com.jetbrains.intellij*`, `org.jetbrains.intellij*`) are shaded.
- **Central artifacts → POM dependencies**: everything else is declared in the published POM instead of bundled — `intellij-platform` 20 `runtime` entries, `intellij-platform-java` 84 (83 `runtime` third-party plus the sibling `intellij-platform` at `compile` scope, since the java JAR's classes extend platform types it deliberately does not contain). Consumers now upgrade e.g. `commons-compress` by normal Gradle conflict resolution — precisely the fix for the Jib incident.
- **JetBrains forks → relocated** under `io.spine.tools.ij`: jdom, log4j, trove4j, fastutil, Batik, ion-java, commons-imaging. Exceptions: JNA is excluded outright and jcef stays unrelocated (their natives bind JNI entry points to literal class names); self-namespaced forks (asm-all, jb-jdi, …) are shaded as is.
- **Dropped entirely** — machinery never exercised by headless PSI, so neither shaded nor declared: pty4j, purejavacomm, jediterm, winp (OS/terminal integration, replacing the incomplete per-file exclude patterns), and the BouncyCastle stack plus `marketplace-zip-signer` (remote-development and plugin-signing crypto — see below).
- The java module's subtraction filter reverse-maps Shadow's transforms (relocated paths, renamed service files, `.shadow.kotlin_module`) via `sourceFormOf`, so nothing duplicates across the pair.

**Result**: `intellij-platform` 25.8 → 17.4 MB, `intellij-platform-java` 115.1 → 78.6 MB.

## The published POM resolves conflict-free

Replacing a dependency-less POM with an 84-entry one moves work onto consumers unless the entries are curated, so three problems found downstream were fixed in this PR after the first review round:

**1. Entries are published non-transitive.** Each declared entry initially carried its own transitive graph, re-requesting `commons-*`, `kotlin-*`, `annotations`, and `objenesis` at the version *that entry* was built against rather than the resolved version pinned here — 10 conflicting modules for a bare consumer under `failOnVersionConflict()`, forcing boilerplate the old dependency-less POM never required. Every entry now carries a wildcard `<exclusions>` block. The declared list is already the complete flattened runtime closure (each entry's transitives are themselves entries), so nothing is lost, every module is requested at exactly one version, and the POM resolves with **zero** conflicts and no consumer-side forces. The curation also becomes authoritative — Slf4J, the Kotlin runtime, and the dropped groups cannot re-enter through an entry's own POM. Consumers still upgrade any entry by ordinary resolution, so the `commons-compress` fix is preserved.

**2. Pins align with the Spine stack.** With entries non-transitive, the remaining conflict source is a pin that disagrees with the consumer's own graph. `core-jvm-compiler/tests` (strict resolution) surfaced Jackson `2.13.0` and Caffeine `3.0.4` — the versions the IJ-213 POMs request, which stood because this repo never forced these families. `uber-jar-module` now forces the Jackson family and Caffeine in the uber modules' resolution, so the published pins are the versions this repository is built and tested with (`2.22.1`/`2.22`, `3.2.4`), the same treatment Guava already receives from `forceVersions()`.

**3. The BouncyCastle clash.** `core-jvm-compiler`'s integration tests hit `Conflict found for module 'org.bouncycastle:bcprov-jdk15on': between versions 1.69 and 1.64` against the `.410` POM: `ide-impl` reaches BouncyCastle by two disagreeing paths — `bcpg-jdk15on:1.69` (via `remote-dev-util`) wants `bcprov:1.69`, while `marketplace-zip-signer:0.1.3` wants `bcpkix:1.64` → `bcprov:1.64`. Neither `bcprov` nor `bcpkix` is on *this* repo's runtime classpath, so the clash was invisible here and surfaced only in consumers, which re-resolve each declared entry's own POM. Both entry points are remote-dev and plugin-signing machinery, so dropping them removes the cryptography surface entirely rather than merely aligning versions. POM entries 86 → 84; `org.jetbrains:annotations` and `annotations-java5` verified to survive the artifact-level drop.

## Verification

- Full `./gradlew build dokkaGenerate` green; `psi` / `psi-java` suites: 148 tests pass against the relocated JARs.
- Both POMs regenerated and inspected: 20 and 84 entries, every one carrying the wildcard exclusion; aligned pins (Jackson `2.22.1`, Caffeine `3.2.4`, Guava `33.6.0-jre`) present as published values.
- All 83 distinct third-party POM entries across both modules verified present on Maven Central (`blockmap`, which is absent from Central, is shaded instead).
- JAR entry listings diffed at every step and byte-identical across the dependency-alignment change; cross-JAR duplicates reduced to `META-INF/MANIFEST.MF` only. The two non-IJ uber modules (`jvm-tool-plugins`, `protobuf-setup-plugins`) are unaffected by the shared forcing block.
- `IntelliJUberJarSpec` (8 tests) covers the pure policy logic — group filtering, per-artifact drops, and all three `sourceFormOf` reversals.
- End-to-end consumer proof: a scratch Gradle project resolving `io.spine.tools:intellij-platform-java:2.0.0-SNAPSHOT.410` from Maven Local gets **85 artifacts** (uber JAR + the sibling at compile scope + all 83 third-party, with `commons-compress:1.21`, `guava:33.6.0-jre`, `jackson-databind:2.22.1` as pinned), and resolves **conflict-free under `failOnVersionConflict()` with no consumer-side forces**.
- Pre-PR reviewer round: spine-code-review, kotlin-engineer, review-docs, dependency-audit, gradle-review — all APPROVE after fixes (tests added, KDoc link repaired, CC-hardening of the subtraction task wiring). Codex's `compile`-scope finding is fixed and resolved.

## Reviewer notes

- The fork relocation is why this bump is **breaking** (version `.404` → `.410`): previously bundled classes disappear or move to `io.spine.tools.ij.*`. No Spine source imports the affected packages (verified by grep).
- Known transition-window skew: Jackson pins still disagree with artifacts published before the stack moved to `2.22.1` (e.g. `compiler-jvm .066` requests `2.21.1` via `palantir-java-format`). The consumer conventions' `JacksonV2` forces cover it until the stack republishes, after which it disappears.
- **The POM is the only metadata these artifacts publish, and that is load-bearing.** Because `fatJar` is an artifact-only publication (`artifact(tasks.shadowJar)`, no software component), Gradle emits no `.module` file — verified: `publishToMavenLocal` yields exactly `.jar` + `.pom` for both IJ modules, while component-based siblings like `psi-java` do get a `.module`. Gradle consumers therefore fall back to the POM this PR populates. If anyone later switches `fatJar` to `from(components[...])`, the generated Module Metadata would take precedence and silently bypass `declareUnshadedDependencies` — disable metadata generation for the publication in that case. (Raised by Copilot; the two threads carry the measurements.)
- Two unrelated one-line edits ride along in `Line.java` and `ExternalModules.java`: parenthesising `instanceof` patterns to clear an ErrorProne `OperatorPrecedence` warning surfaced by these builds.
- A `--configuration-cache` probe is recorded in the task log: the POM-generation tasks execute under CC, but the entry is discarded (the `withXml` action's captured `Configuration` is not serializable; the root script's `gcloud` call is a pre-existing blocker). Full CC readiness is out of scope — the repo does not enable it.
- Remaining follow-up (tracked in the task file): consumer proof in `delivery-server` — drop the `CommonsCompress` classpath-ordering workaround once these artifacts are published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
